### PR TITLE
fix: optimize null checking in parseCodeBlock

### DIFF
--- a/src/utils/markdown-parser/node-parsers/code-block-parser.ts
+++ b/src/utils/markdown-parser/node-parsers/code-block-parser.ts
@@ -2,7 +2,7 @@ import type { CodeBlockNode, MarkdownToken } from '../../../types'
 
 export function parseCodeBlock(token: MarkdownToken): CodeBlockNode {
   const match = token.content.match(/ type="application\/vnd\.ant\.([^"]+)"/)
-  if (match[1]) {
+  if (match?.[1]) {
     // 需要把 <antArtifact> 标签去掉
     token.content = token.content
       .replace(/<antArtifact[^>]*>/g, '')


### PR DESCRIPTION
When we add some HTML tags in content (maybe unexpectedly), such as:
`
Yes, you can see this content:
<div></div>
but the parser will go wrong, and there will be no result anymore
`
The parseCodeBlock function will report an error, and content after this will not be parsed correctly.

<img width="2114" height="986" alt="image" src="https://github.com/user-attachments/assets/031d4bd2-55ce-4b7a-b822-6eed47ff9184" />
