### PR TITLE
 Wired CodeBlockNode to prefer the real safeClean hook from stream-mo…

### DIFF
--- a/test/code-block-editor-lock.test.ts
+++ b/test/code-block-editor-lock.test.ts
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import CodeBlockNode from '../src/components/CodeBlockNode/CodeBlockNode.vue'
+
+interface StreamMonacoHelpers {
+  createEditor: ReturnType<typeof vi.fn>
+  createDiffEditor: ReturnType<typeof vi.fn>
+  updateCode: ReturnType<typeof vi.fn>
+  updateDiff: ReturnType<typeof vi.fn>
+  getEditor: ReturnType<typeof vi.fn>
+  getEditorView: ReturnType<typeof vi.fn>
+  getDiffEditorView: ReturnType<typeof vi.fn>
+  cleanupEditor: ReturnType<typeof vi.fn>
+  safeClean: ReturnType<typeof vi.fn>
+  setTheme: ReturnType<typeof vi.fn>
+}
+
+function getStreamMonacoHelpers(): StreamMonacoHelpers {
+  return (globalThis as any).__streamMonacoHelpers
+}
+
+function resetStreamMonacoHelpers() {
+  const helpers = getStreamMonacoHelpers()
+  const makeEditorView = () => ({
+    getModel: () => ({ getLineCount: () => 1 }),
+    getOption: () => 14,
+    updateOptions: vi.fn(),
+    layout: vi.fn(),
+  })
+
+  helpers.createEditor.mockReset().mockImplementation(async () => {})
+  helpers.createDiffEditor.mockReset().mockImplementation(async () => {})
+  helpers.updateCode.mockReset()
+  helpers.updateDiff.mockReset()
+  helpers.getEditor.mockReset().mockImplementation(() => null)
+  helpers.getEditorView.mockReset().mockReturnValue(makeEditorView())
+  helpers.getDiffEditorView.mockReset().mockReturnValue(makeEditorView())
+  helpers.cleanupEditor.mockReset().mockImplementation(() => {})
+  helpers.safeClean.mockReset().mockImplementation(() => {})
+  helpers.setTheme.mockReset().mockImplementation(async () => {})
+}
+
+async function flushPendingMicrotasks() {
+  await nextTick()
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise<void>(resolve => setTimeout(resolve, 0))
+}
+
+async function waitForCreateEditorCalls(expected: number, helpers: StreamMonacoHelpers, timeout = 1000) {
+  const start = Date.now()
+  while (helpers.createEditor.mock.calls.length < expected) {
+    if (Date.now() - start > timeout)
+      throw new Error('Timed out waiting for createEditor call')
+    await flushPendingMicrotasks()
+  }
+}
+
+describe('codeBlockNode editor creation locking', () => {
+  beforeEach(() => {
+    resetStreamMonacoHelpers()
+  })
+
+  it('invokes createEditor only once while loading toggles mid-creation', async () => {
+    const helpers = getStreamMonacoHelpers()
+    let resolveCreate: (() => void) | null = null
+    helpers.createEditor.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = () => resolve()
+        }),
+    )
+
+    const wrapper = mount(CodeBlockNode, {
+      props: {
+        node: {
+          type: 'code_block',
+          language: 'js',
+          code: 'console.log(1)',
+          raw: '```js\nconsole.log(1)\n```',
+        },
+        loading: true,
+        stream: true,
+        showHeader: false,
+      },
+    })
+
+    await flushPendingMicrotasks()
+    expect(wrapper.find('.code-editor-container').exists()).toBe(true)
+
+    await waitForCreateEditorCalls(1, helpers)
+
+    await wrapper.setProps({ loading: false })
+    await flushPendingMicrotasks()
+    expect(helpers.createEditor).toHaveBeenCalledTimes(1)
+
+    const finish = resolveCreate
+    if (finish)
+      finish()
+    await flushPendingMicrotasks()
+    wrapper.unmount()
+  })
+})

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -30,27 +30,39 @@ if (!(globalThis as any).atob) {
   ;(globalThis as any).atob = (input: string) => Buffer.from(input, 'base64').toString('utf-8')
 }
 
+const editorView = {
+  getModel: () => ({ getLineCount: () => 1 }),
+  getOption: () => 14,
+  updateOptions: () => {},
+  layout: () => {},
+}
+
+const diffEditorView = {
+  getModel: () => ({ getLineCount: () => 1 }),
+  getOption: () => 14,
+  updateOptions: () => {},
+  layout: () => {},
+}
+
+const streamMonacoHelpers = {
+  createEditor: vi.fn(async () => {}),
+  createDiffEditor: vi.fn(async () => {}),
+  updateCode: vi.fn(),
+  updateDiff: vi.fn(),
+  getEditor: vi.fn(() => null),
+  getEditorView: vi.fn(() => editorView),
+  getDiffEditorView: vi.fn(() => diffEditorView),
+  cleanupEditor: vi.fn(() => {}),
+  safeClean: vi.fn(() => {}),
+  setTheme: vi.fn(async () => {}),
+}
+
+// Tests reach into this global handle to reset/inspect the shared stream-monaco mock.
+;(globalThis as any).__streamMonacoHelpers = streamMonacoHelpers
+
 vi.mock('stream-monaco', () => ({
-  useMonaco: () => ({
-    createEditor: () => {},
-    createDiffEditor: () => {},
-    updateCode: () => {},
-    updateDiff: () => {},
-    getEditor: () => null,
-    getEditorView: () => ({
-      getModel: () => ({ getLineCount: () => 1 }),
-      getOption: () => 14,
-      updateOptions: () => {},
-    }),
-    getDiffEditorView: () => ({
-      getModel: () => ({ getLineCount: () => 1 }),
-      getOption: () => 14,
-      updateOptions: () => {},
-    }),
-    cleanupEditor: () => {},
-    setTheme: async () => {},
-  }),
-  preloadMonacoWorkers: () => {},
+  useMonaco: () => streamMonacoHelpers,
+  preloadMonacoWorkers: vi.fn(async () => {}),
   detectLanguage: () => 'plaintext',
 }))
 


### PR DESCRIPTION
…naco, falling back to cleanupEditor only when necessary; basic regression test for codeBlockNode; promise lock to prevent duplication monaco

Fix https://github.com/Simon-He95/vue-markdown-renderer/issues/112

