### PR TITLE
docs: Adds examples of overriding internal image nodes with custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,147 @@ setCustomComponents({
 })
 ```
 
+### Custom Image Component Example: Overriding the Internal Image Node
+
+The following example demonstrates how to create a custom image component with preview functionality to replace the default `image` node rendering.
+
+#### Overridable Internal Node Types
+
+This library supports overriding rendering components for the following node types:
+
+**Block Elements**
+- `text`: Plain text
+- `paragraph`: Paragraph
+- `heading`: Heading (lines starting with `#`)
+- `code_block`: Code block (code wrapped in ` ``` `)
+- `list`: List (ordered and unordered lists)
+- `blockquote`: Blockquote (paragraphs starting with `>`)
+- `table`: Table
+- `definition_list`: Definition list (combination of terms and definitions)
+- `footnote`: Footnote
+- `admonition`: Admonition block (such as note, warning, etc.)
+- `thematic_break`: Horizontal rule (such as `---` or `***`)
+- `math_block`: Math formula block (formulas wrapped in `$$`)
+- `mermaid`: Mermaid diagram code block
+
+**Inline Elements**
+- `hardbreak`: Hard line break
+- `link`: Link
+- `image`: Image
+- `math_inline`: Inline math formula (formulas wrapped in `$`)
+- `strong`: Bold text
+- `emphasis`: Italic text
+- `strikethrough`: Strikethrough text
+- `highlight`: Highlighted text
+- `insert`: Inserted text
+- `subscript`: Subscript text
+- `superscript`: Superscript text
+- `emoji`: Emoji
+- `checkbox`: Checkbox
+- `inline_code`: Inline code
+- `reference`: Reference (in the form `[id]: URL`)
+
+#### Implementation Steps
+
+**1. Create a Custom Image Component**
+
+Create an `ImageViewer.vue` component to implement image preview functionality:
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+
+// Define image node type
+interface ImageNode {
+  type: 'image'
+  src: string
+  alt: string
+  title: string | null
+  raw: string
+}
+
+const props = defineProps<{
+  node: ImageNode & { loading?: boolean }
+}>()
+
+// Extract src and alt from the node object
+const src = computed(() => props.node.src)
+const alt = computed(() => props.node.alt || '')
+
+</script>
+
+<template>
+  <div class="image-wrapper">
+    <!-- Thumbnail -->
+    <img
+      :src="src"
+      :alt="alt"
+      :title="node.title || undefined"
+      class="image-thumbnail"
+      :class="{ loading: isLoading }"
+      @click="openPreview"
+    >
+  </div>
+</template>
+```
+
+**2. Register the Custom Component**
+
+Register the custom component in the page where you use the Markdown renderer:
+
+```vue
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import MarkdownRender, { removeCustomComponents, setCustomComponents } from 'vue-renderer-markdown'
+import ImageViewer from './components/ImageViewer.vue'
+
+// Register the custom image component (using a unique ID)
+setCustomComponents('custom-image-demo', {
+  image: ImageViewer
+})
+
+const markdown = `
+# Image Preview Example
+
+Click the image below to enlarge:
+
+![Example Image](https://picsum.photos/800/600)
+
+Supports mouse wheel zoom and ESC key to close.
+`
+
+// Clean up the custom component registration when component unmounts
+onUnmounted(() => {
+  removeCustomComponents('custom-image-demo')
+})
+</script>
+
+<template>
+  <MarkdownRender
+    :content="markdown"
+    custom-id="custom-image-demo"
+  />
+</template>
+```
+
+#### Key Points
+
+1. **Node Interface Definition**: Custom components must accept a `node` prop whose type matches the node type being overridden. For example, `ImageNode` contains `src`, `alt`, `title`, and `raw` properties.
+
+2. **Scoped Registration**: It is recommended to use `setCustomComponents(id, mapping)` for scoped registration and specify the corresponding `custom-id` on the `MarkdownRender` component. This avoids global pollution and allows different renderer instances to use different custom components.
+
+3. **Cleanup Registration**: Use `removeCustomComponents(id)` to clean up the registration when the component unmounts to prevent memory leaks.
+
+4. **Feature Enhancement**: Custom components can add any functionality you need, such as image preview, zoom, keyboard shortcuts, etc.
+
+5. **Style Customization**: You have complete control over the styles of custom components without being restricted by default styles.
+
+#### Complete Example
+
+For a complete implementation example, refer to the `playground/src/pages/customImage.vue` and `playground/src/components/imageViewer.vue` files in the repository.
+
+Live demo: https://vue-markdown-renderer.simonhe.me/customImage
+
 #### MarkdownCodeBlockNode: Alternative Code Block Renderer
 
 The library now includes `MarkdownCodeBlockNode` - an alternative code block component that provides markdown-style syntax highlighting instead of Monaco Editor integration. This gives you the flexibility to choose between two rendering approaches for code blocks:

--- a/playground/components.d.ts
+++ b/playground/components.d.ts
@@ -9,6 +9,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     Counter: typeof import('./src/components/Counter.vue')['default']
     Footer: typeof import('./src/components/Footer.vue')['default']
+    ImageViewer: typeof import('./src/components/imageViewer.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     ThinkingNode: typeof import('./src/components/ThinkingNode.vue')['default']

--- a/playground/src/components/imageViewer.vue
+++ b/playground/src/components/imageViewer.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+
+// 定义图片节点类型
+interface ImageNode {
+  type: 'image'
+  src: string
+  alt: string
+  title: string | null
+  raw: string
+}
+
+const zoom = ref(1)
+const minZoom = 0.2
+const maxZoom = 3
+const zoomStep = 0.1
+
+const onWheel = (e: WheelEvent) => {
+  if (!showPreview.value) return
+  e.preventDefault()
+  // 鼠标滚轮也可缩放
+  if (e.deltaY < 0) {
+    zoom.value = Math.min(maxZoom, +(zoom.value + zoomStep).toFixed(2))
+  } else {
+    zoom.value = Math.max(minZoom, +(zoom.value - zoomStep).toFixed(2))
+  }
+}
+
+const props = defineProps<{
+  node: ImageNode & { loading?: boolean }
+}>()
+
+// 从 node 对象中提取 src 和 alt
+const src = computed(() => props.node.src)
+const alt = computed(() => props.node.alt || '')
+
+const showPreview = ref(false)
+const isLoading = ref(true)
+
+const openPreview = () => {
+  showPreview.value = true
+  zoom.value = 1
+}
+
+const closePreview = () => {
+  showPreview.value = false
+}
+
+// ESC 键关闭
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape' && showPreview.value) {
+    closePreview()
+  }
+}
+
+const handleError = () => {
+  isLoading.value = false
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+  // 检测图片加载完成
+  const img = new Image()
+  img.onload = () => {
+    isLoading.value = false
+  }
+  img.onerror = () => {
+    isLoading.value = false
+  }
+  img.src = src.value
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <div class="image-wrapper">
+    <!-- 缩略图 -->
+    <img
+      :src="src"
+      :alt="alt"
+      :title="node.title || undefined"
+      class="image-thumbnail"
+      :class="{ loading: isLoading }"
+      @click="openPreview"
+      @error="handleError"
+    />
+
+    <!-- 放大预览弹窗 -->
+    <Teleport to="body">
+      <Transition name="preview-fade">
+        <div v-if="showPreview" class="image-preview-overlay" @click="closePreview">
+          <div class="preview-container" @click.stop>
+            <img
+              :src="src"
+              :alt="alt"
+              class="preview-image"
+              :style="{ transform: `scale(${zoom})` }"
+              @wheel="onWheel"
+              draggable="false"
+            />
+          </div>
+          <button class="preview-close" @click="closePreview" title="关闭 (ESC)">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path d="M18 6L6 18M6 6l12 12" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </button>
+          <div class="preview-zoom-ctrl-bottom">
+            <input
+              type="range"
+              class="zoom-slider"
+              :min="minZoom"
+              :max="maxZoom"
+              :step="zoomStep"
+              v-model.number="zoom"
+            />
+            <span class="zoom-text">{{ Math.round(zoom * 100) }}%</span>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.preview-zoom-ctrl-bottom {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 8px 18px;
+  border-radius: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.zoom-slider {
+  width: 120px;
+  accent-color: #409eff;
+  margin-right: 10px;
+  vertical-align: middle;
+  height: 4px;
+}
+.zoom-text {
+  color: #fff;
+  font-size: 15px;
+  min-width: 48px;
+  text-align: center;
+  user-select: none;
+}
+.preview-container {
+  position: relative;
+}
+.preview-image {
+  transition: transform 0.2s cubic-bezier(0.4, 2, 0.6, 1);
+}
+.image-wrapper {
+  display: inline-block;
+  margin: 4px 0;
+  vertical-align: middle;
+}
+
+.image-thumbnail {
+  max-width: 300px;
+  max-height: 200px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: block;
+}
+
+.image-thumbnail:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: scale(1.02);
+}
+
+.image-thumbnail.loading {
+  opacity: 0.6;
+  background: #f3f4f6;
+}
+
+/* 预览弹窗样式 */
+.image-preview-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+}
+
+.preview-container {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  cursor: default;
+}
+
+.preview-image {
+  max-width: 90vw;
+  max-height: 90vh;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: block;
+}
+
+.preview-close {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: #333;
+  z-index: 10000;
+}
+.preview-close:hover {
+  background: white;
+  transform: scale(1.1);
+}
+
+.preview-fade-enter-from .preview-container {
+  transform: scale(0.9);
+}
+
+.preview-fade-leave-to .preview-container {
+  transform: scale(0.9);
+}
+</style>

--- a/playground/src/pages/customImage.vue
+++ b/playground/src/pages/customImage.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { onUnmounted, ref } from 'vue'
+import MarkdownRender from '../../../src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents } from '../../../src/utils/nodeComponents'
+import ImageViewer from '../components/imageViewer.vue'
+import KatexWorker from '../../../src/workers/katexRenderer.worker?worker&inline'
+import { setKaTeXWorker } from '../../../src/workers/katexWorkerClient'
+import MermaidWorker from '../../../src/workers/mermaidParser.worker?worker&inline'
+import { setMermaidWorker } from '../../../src/workers/mermaidWorkerClient'
+import 'katex/dist/katex.min.css'
+
+// 初始化 Workers
+setKaTeXWorker(new KatexWorker())
+setMermaidWorker(new MermaidWorker())
+
+// 注册自定义图片组件
+setCustomComponents('custom-image-demo', { image: ImageViewer })
+
+// 示例 Markdown 内容，包含图片
+const content = ref(`
+# 自定义图片渲染示例
+
+这是一个使用自定义组件渲染图片的示例。点击图片可以放大预览。点开的图不一样是因为接口返回的是随机图片。
+
+## 示例图片
+
+![示例图片](https://picsum.photos/800/600?random=1)
+
+这是一张随机图片，支持点击放大、缩放等功能。
+
+![另一张图片](https://picsum.photos/600/400?random=2)
+
+## 功能特点
+
+- 点击图片放大预览
+- 支持鼠标滚轮缩放
+- 支持滑块调节缩放比例
+- ESC 键关闭预览
+- 优雅的过渡动画
+`)
+
+// 清理自定义组件
+onUnmounted(() => {
+  try {
+    removeCustomComponents('custom-image-demo')
+  }
+  catch (error) {
+    console.error('Failed to remove custom components:', error)
+  }
+})
+</script>
+
+<template>
+  <div class="custom-image-page">
+    <div class="container">
+      <div class="header">
+        <h1>自定义图片渲染演示</h1>
+        <p class="subtitle">使用 setCustomComponents 注册 imageViewer 组件实现自定义图片渲染</p>
+      </div>
+
+      <div class="content-wrapper">
+        <MarkdownRender
+          :content="content"
+          custom-id="custom-image-demo"
+          class="markdown-content"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.custom-image-page {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 2rem;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+.header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.header h1 {
+  margin: 0 0 1rem 0;
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  opacity: 0.95;
+  font-weight: 300;
+}
+
+.content-wrapper {
+  padding: 2rem;
+}
+
+.markdown-content {
+  line-height: 1.8;
+  color: #333;
+}
+
+.markdown-content :deep(h2) {
+  color: #667eea;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.markdown-content :deep(p) {
+  margin-bottom: 1rem;
+  color: #555;
+}
+
+.markdown-content :deep(ul) {
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.markdown-content :deep(li) {
+  margin-bottom: 0.5rem;
+  color: #555;
+}
+
+/* 暗色主题支持 */
+@media (prefers-color-scheme: dark) {
+  .container {
+    background: #1a1a2e;
+  }
+
+  .markdown-content {
+    color: #e0e0e0;
+  }
+
+  .markdown-content :deep(h2) {
+    color: #8b9bea;
+  }
+
+  .markdown-content :deep(p),
+  .markdown-content :deep(li) {
+    color: #c0c0c0;
+  }
+}
+</style>


### PR DESCRIPTION
about [issue125](https://github.com/Simon-He95/vue-markdown-renderer/issues/125)
