### PR TITLE
feat(markdown)!: strict math delimiters, robust inline code parsing; drop plain parentheses as math

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,17 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.4",
-    "stream-markdown-parser": "^0.0.30"
+    "markdown-it": "^14.1.0",
+    "markdown-it-container": "^4.0.0",
+    "markdown-it-emoji": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-ins": "^4.0.0",
+    "markdown-it-mark": "^4.0.0",
+    "markdown-it-sub": "^2.0.0",
+    "markdown-it-sup": "^2.0.0",
+    "markdown-it-task-checkbox": "^1.0.6",
+    "markdown-it-ts": "0.0.2-beta.4",
+    "stream-markdown-parser": "workspace:^"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",

--- a/packages/markdown-parser/src/config.ts
+++ b/packages/markdown-parser/src/config.ts
@@ -12,6 +12,13 @@ export interface MathOptions {
   commands?: readonly string[]
   /** Whether to escape standalone '!' (default: true). */
   escapeExclamation?: boolean
+  /**
+   * Strict delimiter mode.
+   * - When true, only explicit TeX delimiters are recognized as math:
+   *   inline: `$...$` and `\(...\)`; block: `$$...$$` and `\[...\]`.
+   * - Heuristics and mid-state (unclosed) math detection are disabled.
+   */
+  strictDelimiters?: boolean
 }
 
 let defaultMathOptions: MathOptions | undefined

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -46,6 +46,22 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
   const result: ParsedNode[] = []
   let currentTextNode: TextNode | null = null
 
+  // Fallback: markdown-it sometimes mis-tokenizes code_inline around CJK text
+  // yielding code_inline nodes that contain non-ASCII prose (e.g. "方法会根据").
+  // When detected, prefer re-parsing from the original raw string to rebuild
+  // inline_code spans and basic strong emphasis segments in a stable way.
+  const hasSuspiciousCodeInline = tokens.some(t => t.type === 'code_inline' && /[^\x00-\x7F]/.test(String(t.content ?? '')))
+  const hasBackticksInRaw = typeof raw === 'string' && /`/.test(raw)
+  const codeInlineCount = tokens.reduce((n, t) => n + (t.type === 'code_inline' ? 1 : 0), 0)
+  const rawBacktickCount = typeof raw === 'string' ? ((raw.match(/`/g) || []).length) : 0
+  // When backtick count is even, expected inline-code spans ~= backtickCount/2.
+  const expectedSpans = rawBacktickCount % 2 === 0 ? rawBacktickCount / 2 : 0
+  const mismatchedSpanCount = expectedSpans > 0 && codeInlineCount !== expectedSpans
+  const hasMathInlineUsingBackticks = tokens.some(t => t.type === 'math_inline' && /`/.test(String((t as any).raw ?? t.content ?? '')))
+  if (hasBackticksInRaw && (hasSuspiciousCodeInline || mismatchedSpanCount || hasMathInlineUsingBackticks)) {
+    return parseFromRawWithCodeAndStrong(String(raw ?? ''))
+  }
+
   let i = 0
   // Note: strong-token normalization and list-item normalization are
   // applied during markdown-it parsing via core rules (plugins that
@@ -174,57 +190,49 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
     if (!/`[^`]*/.test(content))
       return false
 
-    // Close any current text node and handle inline code
-    resetCurrentTextNode()
     const code_start = content.indexOf('`')
     const code_end = content.indexOf('`', code_start + 1)
-    const _text = content.slice(0, code_start)
-    const codeContent = code_end === -1 ? content.slice(code_start) : content.slice(code_start, code_end)
-    const after = code_end === -1 ? '' : content.slice(code_end + 1)
-    if (_text) {
-      // Try to re-run emphasis/strong parsing on the fragment before the code span
-      // but avoid mutating the outer token index `i` (handlers sometimes increment it).
-      const handled = handleEmphasisAndStrikethrough(_text, _token)
-      // restore index so we don't skip tokens in the outer loop
-      if (!handled) {
-        pushText(_text, _text)
-      }
-      else {
-        i--
-      }
+
+    // If we don't have a closing backtick within this token, don't emit a partial
+    // inline_code node. Instead, merge the rest of inline tokens into a single
+    // string and re-run parsing so the code span is handled atomically.
+    if (code_end === -1) {
+      let merged = content
+      for (let j = i + 1; j < tokens.length; j++)
+        merged += String((tokens[j].content ?? '') + (tokens[j].markup ?? ''))
+
+      // Consume to the end since we've merged remaining tokens
+      i = tokens.length - 1
+      handleToken({ type: 'text', content: merged, raw: merged } as unknown as MarkdownToken)
+      i++
+      return true
     }
 
-    const code = codeContent.replace(/`/g, '')
+    // Close any current text node and handle the text before the code span
+    resetCurrentTextNode()
+    const beforeText = content.slice(0, code_start)
+    const codeContent = content.slice(code_start + 1, code_end)
+    const after = content.slice(code_end + 1)
+
+    if (beforeText) {
+      // Try to parse emphasis/strong inside the pre-code fragment, without
+      // advancing the outer token index `i` permanently.
+      const handled = handleEmphasisAndStrikethrough(beforeText, _token)
+      if (!handled)
+        pushText(beforeText, beforeText)
+      else
+        i--
+    }
+
     pushParsed({
       type: 'inline_code',
-      code,
-      raw: String(code ?? ''),
+      code: codeContent,
+      raw: String(codeContent ?? ''),
     } as ParsedNode)
 
-    // afterCode 可能也存在很多情况包括多个 code，我们递归处理 --- IGNORE ---
     if (after) {
-      handleToken({
-        type: 'text',
-        content: after,
-        raw: String(after ?? ''),
-      })
+      handleToken({ type: 'text', content: after, raw: after } as unknown as MarkdownToken)
       i--
-    }
-    else if (code_end === -1) {
-      // 要把下一个 token 也合并进来，把类型变成 text
-      const nextToken = tokens[i + 1]
-      if (nextToken) {
-        let fixedAfter = after
-        for (let j = i + 1; j < tokens.length; j++) {
-          fixedAfter += String(((tokens[j].content ?? '') + (tokens[j].markup ?? '')))
-        }
-        i = tokens.length - 1
-        handleToken({
-          type: 'text',
-          content: fixedAfter,
-          raw: String(fixedAfter ?? ''),
-        })
-      }
     }
     i++
     return true
@@ -862,4 +870,80 @@ export function parseInlineTokens(tokens: MarkdownToken[], raw?: string, pPreTok
   }
 
   return result
+}
+
+// Minimal, robust fallback parser: split raw by backticks into
+// text and inline_code, and parse simple **strong** inside text.
+function parseFromRawWithCodeAndStrong(raw: string): ParsedNode[] {
+  // Tokenize raw handling two constructs: backticks `...` and strong **...**
+  // Build a small AST allowing code inside strong and vice versa.
+  const root: ParsedNode[] = []
+  const stack: Array<{ type: 'root' | 'strong', children: ParsedNode[] }> = [{ type: 'root', children: root }]
+  let i = 0
+
+  function cur() { return stack[stack.length - 1].children }
+
+  function pushText(s: string) {
+    if (!s)
+      return
+    const last = cur()[cur().length - 1]
+    if (last && last.type === 'text') {
+      (last as any).content += s
+      ;(last as any).raw += s
+    }
+    else {
+      cur().push({ type: 'text', content: s, raw: s } as ParsedNode)
+    }
+  }
+
+  while (i < raw.length) {
+    // strong open/close
+    if (raw[i] === '*' && raw[i + 1] === '*') {
+      // If already inside strong, close it; otherwise open new strong
+      const isClosing = stack.length > 1 && stack[stack.length - 1].type === 'strong'
+      i += 2
+      if (isClosing) {
+        const nodeChildren = stack.pop()!.children
+        cur().push({ type: 'strong', children: nodeChildren, raw: `**${nodeChildren.map(n => (n as any).raw ?? '').join('')}**` } as ParsedNode)
+      }
+      else {
+        stack.push({ type: 'strong', children: [] })
+      }
+      continue
+    }
+
+    // inline code
+    if (raw[i] === '`') {
+      const start = i
+      const close = raw.indexOf('`', i + 1)
+      if (close === -1) {
+        // no closing tick; treat as text
+        pushText(raw.slice(i))
+        break
+      }
+      const code = raw.slice(i + 1, close)
+      cur().push({ type: 'inline_code', code, raw: code } as ParsedNode)
+      i = close + 1
+      continue
+    }
+
+    // regular text: read until next special
+    let next = raw.indexOf('`', i)
+    const nextStrong = raw.indexOf('**', i)
+    if (nextStrong !== -1 && (next === -1 || nextStrong < next))
+      next = nextStrong
+    if (next === -1)
+      next = raw.length
+    pushText(raw.slice(i, next))
+    i = next
+  }
+
+  // If there are unclosed strongs, degrade them into plain text with ** markers
+  while (stack.length > 1) {
+    const dangling = stack.pop()!
+    const content = dangling.children.map(n => (n as any).raw ?? (n as any).content ?? '').join('')
+    pushText(`**${content}`)
+  }
+
+  return root
 }

--- a/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/list-parser.ts
@@ -63,11 +63,7 @@ export function parseList(
           tokens[k].type === 'bullet_list_open'
           || tokens[k].type === 'ordered_list_open'
         ) {
-          if (tokens[k].markup === '*') {
-            k++
-            continue
-          }
-          // Parse nested list
+          // Parse nested list (do not skip '*' — treat all bullet types consistently)
           const [nestedListNode, newIndex] = parseNestedList(tokens, k)
           itemChildren.push(nestedListNode)
           k = newIndex
@@ -206,11 +202,6 @@ function parseNestedList(
           tokens[k].type === 'bullet_list_open'
           || tokens[k].type === 'ordered_list_open'
         ) {
-          if (tokens[k].markup === '*') {
-            k++
-            continue
-          }
-
           // Handle deeper nested lists
           const [deeperNestedListNode, newIndex] = parseNestedList(tokens, k)
           itemChildren.push(deeperNestedListNode)

--- a/packages/markdown-parser/src/plugins/isMathLike.ts
+++ b/packages/markdown-parser/src/plugins/isMathLike.ts
@@ -90,9 +90,11 @@ export function isMathLike(s: string) {
   const funcCall = FUNC_CALL_RE.test(norm)
   // common math words
   const words = WORDS_RE.test(norm)
-  // 纯单个英文字母也渲染成数学公式
-  // e.g. (w) (x) (y) (z)
-  const pureWord = /^\([a-z]\)$/i.test(stripped)
+  // 纯单个英文字母也渲染成数学公式（常见变量/元素符号）
+  // e.g. (w) (x) (y) (z) 或 $H$, $x$ 等
+  const pureWord = /^\([a-z]\)$/i.test(stripped) || /^[a-z]$/i.test(stripped)
+  // 简单的化学式/下标：如 H_2O, CO_2, CH_3CH_2OH, CH_3COOH
+  const chemicalLike = /^(?:[A-Z][a-z]?(_\{?[A-Za-z0-9]+\}?|\^[A-Za-z0-9]+)?)+$/i.test(stripped)
 
-  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || words || pureWord
+  return texCmd || texCmdWithBraces || texBraceStart || texSpecific || superSub || ops || funcCall || words || pureWord || chemicalLike
 }

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -198,14 +198,18 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
   // Inline rule for \(...\) and $$...$$ and $...$
   const mathInline = (state: unknown, silent: boolean) => {
     const s = state as any
+    const strict = !!mathOpts?.strictDelimiters
 
     if (/^\*[^*]+/.test(s.src)) {
       return false
     }
     const delimiters: [string, string][] = [
       ['$', '$'],
+      // Support explicit TeX inline delimiters only: \( ... \)
       ['\\(', '\\)'],
-      ['\(', '\)'],
+      // Do NOT treat plain parentheses as math delimiters. Using ['\(', '\)']
+      // accidentally becomes ['(', ')'] in JS/TS strings and over-matches
+      // regular text like "(0 <= t < S-1)", causing false math detection.
     ]
 
     let searchPos = 0
@@ -276,7 +280,8 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
             continue
           }
           if (endIdx === -1) {
-            if (isMathLike(content)) {
+            // Do not treat segments containing inline code as math
+            if (!strict && isMathLike(content) && !content.includes('`')) {
               searchPos = index + open.length
               foundAny = true
               if (!silent) {
@@ -321,7 +326,13 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
           }
         }
         const content = src.slice(index + open.length, endIdx)
-        if (!isMathLike(content)) {
+        // Skip treating as math when the content contains inline-code backticks
+        // Always accept explicit dollar-delimited math ($...$) even if the
+        // heuristic deems it not math-like (to support cases like $H$, $CO_2$).
+        const hasBacktick = content.includes('`')
+        const isDollar = open === '$'
+        const shouldSkip = strict ? hasBacktick : (hasBacktick || (!isDollar && !isMathLike(content)))
+        if (shouldSkip) {
           // push remaining text after last match
           // not math-like; skip this match and continue scanning
           searchPos = endIdx + close.length
@@ -427,11 +438,17 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
     silent: boolean,
   ) => {
     const s = state as any
-    const delimiters: [string, string][] = [
-      ['\\[', '\\]'],
-      ['\[', '\]'],
-      ['$$', '$$'],
-    ]
+    const strict = !!mathOpts?.strictDelimiters
+    const delimiters: [string, string][] = strict
+      ? [
+          ['\\[', '\\]'],
+          ['$$', '$$'],
+        ]
+      : [
+          ['\\[', '\\]'],
+          ['\[', '\]'],
+          ['$$', '$$'],
+        ]
     const startPos = s.bMarks[startLine] + s.tShift[startLine]
     const lineText = s.src.slice(startPos, s.eMarks[startLine]).trim()
     let matched = false
@@ -524,6 +541,10 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
         content += (content ? '\n' : '') + currentLine
       }
     }
+
+    // In strict mode, do not emit mid-state (unclosed) block math
+    if (strict && !found)
+      return false
 
     const token: any = s.push('math_block', 'math', 0)
     token.content = normalizeStandaloneBackslashT(content)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,36 @@ importers:
       katex:
         specifier: '>=0.16.22'
         version: 0.16.25
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
+      markdown-it-container:
+        specifier: ^4.0.0
+        version: 4.0.0
+      markdown-it-emoji:
+        specifier: ^3.0.0
+        version: 3.0.0
+      markdown-it-footnote:
+        specifier: ^4.0.0
+        version: 4.0.0
+      markdown-it-ins:
+        specifier: ^4.0.0
+        version: 4.0.0
+      markdown-it-mark:
+        specifier: ^4.0.0
+        version: 4.0.0
+      markdown-it-sub:
+        specifier: ^2.0.0
+        version: 2.0.0
+      markdown-it-sup:
+        specifier: ^2.0.0
+        version: 2.0.0
+      markdown-it-task-checkbox:
+        specifier: ^1.0.6
+        version: 1.0.6
+      markdown-it-ts:
+        specifier: 0.0.2-beta.4
+        version: 0.0.2-beta.4
       mermaid:
         specifier: '>=11'
         version: 11.12.1
@@ -24,8 +54,8 @@ importers:
         specifier: '>=0.0.10'
         version: 0.0.10(shiki@3.15.0)
       stream-markdown-parser:
-        specifier: ^0.0.30
-        version: 0.0.30
+        specifier: workspace:^
+        version: link:packages/markdown-parser
       stream-monaco:
         specifier: '>=0.0.6'
         version: 0.0.6(monaco-editor@0.52.2)
@@ -3175,6 +3205,10 @@ packages:
     resolution: {integrity: sha512-IODjyQuedEjZkUoILLHOvPvG1CEyDECr8bja5VLTwQ2UD0wGSA9guNrD+ko8t5LLR1dglcBTEsMw9iYt7Ngrsg==}
     engines: {node: '>=18'}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -3951,9 +3985,6 @@ packages:
 
   stream-markdown-parser@0.0.29:
     resolution: {integrity: sha512-ZKn+plQ7rtanWhh3dwcOTeOu4ph4J12elOvq7+hJJbbIWTKIly8JFQMaJ4iAf527cmyQIIuzmh75bq/PR3PJNQ==}
-
-  stream-markdown-parser@0.0.30:
-    resolution: {integrity: sha512-naWIooFNnhi+lO2obMfHQiv6xyHjgcDiaIaE/jNTrEfh/zDkQSBHEuL/nO1ToNaXZPj/JHFBp6qKMUNeaSbsXA==}
 
   stream-markdown@0.0.10:
     resolution: {integrity: sha512-k3B1h1gUga0nArchDSD6O8+rxXiL6WvuZ11hZgxpYy9Z1Pihjt8rYROoTdJeC2k2ymctLYTDIGRI6AASjipLeg==}
@@ -7836,6 +7867,15 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
@@ -8792,18 +8832,6 @@ snapshots:
   std-env@3.10.0: {}
 
   stream-markdown-parser@0.0.29:
-    dependencies:
-      markdown-it-container: 4.0.0
-      markdown-it-emoji: 3.0.0
-      markdown-it-footnote: 4.0.0
-      markdown-it-ins: 4.0.0
-      markdown-it-mark: 4.0.0
-      markdown-it-sub: 2.0.0
-      markdown-it-sup: 2.0.0
-      markdown-it-task-checkbox: 1.0.6
-      markdown-it-ts: 0.0.2-beta.4
-
-  stream-markdown-parser@0.0.30:
     dependencies:
       markdown-it-container: 4.0.0
       markdown-it-emoji: 3.0.0

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,15 +84,6 @@ export default defineConfig(({ mode }) => {
             return true
           return [
             'vue',
-            'markdown-it-ts',
-            'markdown-it-container',
-            'markdown-it-emoji',
-            'markdown-it-footnote',
-            'markdown-it-ins',
-            'markdown-it-mark',
-            'markdown-it-sub',
-            'markdown-it-sup',
-            'markdown-it-task-checkbox',
             'vue-i18n',
             'katex',
             'stream-monaco',


### PR DESCRIPTION
feat(markdown)!: strict math delimiters, robust inline code parsing; drop plain parentheses as math

- Add MathOptions.strictDelimiters (inline: $...$, \\(...\\); block: $$...$$, \\[...\\])
- Strict mode: disable heuristics and mid-state (unclosed) math tokens
- Always accept $...$ as inline math (unless content contains backticks)
- Remove plain parentheses as inline math delimiters to prevent false positives (use \\(...\\) or $...$ instead)
- Fix inline code parsing:
    - Avoid emitting partial code spans when closing backtick is missing
    - Merge remaining fragments and re-parse atomically
    - Add raw-based fallback that rebuilds inline_code and strong across backticks, preserving CJK text
- Fix nested list parsing: stop skipping *-bullet nested lists; parse uniformly
- Tune math heuristic (non-strict path): recognise simple chemistry forms (e.g. H_2O, CH_3CH_2OH) and single-letter tokens; $...$ path no longer depends on heuristics
- Add scripts/debug-parse.mjs for token/node inspection in local dev

BREAKING CHANGE: plain ( ... ) is no longer treated as inline math. Use \\(...\\) or $...$ for inline formulas.

Testcases:
```markdown
3.  **多维度波动性估计 (`longTermDeviation()`)**
    *   这是计算阈值“宽度”的关键，它结合了三种不同的波动性视角：
        *   **`primaryDeviation.getDeviation()`**: 衡量 RCF 原始分数本身的整体波动（EWMA 标准差）。
        *   **`secondaryDeviation.getDeviation()`**: 衡量 RCF 原始分数的**瞬时变化率**（即 `current_score - last_score`）的波动。这对于捕捉突变非常有效。
        *   **`thresholdDeviation.getDeviation()`**: 专门捕捉当分数低于其均值时，分数与均值之间差值的波动。这进一步强化了对**分数非对称性**的理解，因为它更关注“正常”分数分布的下半部分。
    *   **融合机制**: `longTermDeviation()` 方法会根据 `shingleSize` 和 `transformMethod` 的类型，以及 `scoreDifferencing` 参数（一个 `[0, 1]` 的权重因子），**加权融合**这些不同的波动性估计。例如，`scoreDifferencing` 倾向于分数本身的波动，而 `1 - scoreDifferencing` 倾向于分数变化率的波动。
    *   **设计理念**: 分数的异常行为可能表现为多种形式：整体水平的漂移、突然的尖峰、或者持续的轻微增长。通过结合多种波动性度量，模型能够更全面、更鲁棒地估计“正常”分数的变异性，从而使阈值能够响应不同类型的异常信号。


---
#### **Q2: 模型从开始处理数据到输出可靠结果，需要经历哪些阶段？何时才算“完全正常运行”？**

**A:** 模型达到完全稳定需要经过多个阶段，其稳定时间点由 `shingle_size (S)`, `tree_size (T)`, `time_decay (D)` 和 `calibrator_window_size (W_C)` 共同决定。

1.  **阶段 1: Shingle 缓冲区填充 (`t < S - 1`)**: 模型未运行。
2.  **阶段 2: RRCF 树填充 (`S - 1 <= t < (S - 1) + T`)**: 模型开始学习，但分数不稳定。
3.  **阶段 3: 完全指数衰减运行 (`t >= (S - 1) + D`)**: 模型核心评分功能稳定。
4.  **阶段 4: 完全正常运行 (`t >= (S - 1) + max(T, D, W_C)`)**: 整个系统（模型+校准器）稳定，输出的异常概率可靠。

**结论**: 系统在处理了至少 `(S - 1) + max(T, D, W_C)` 个原始数据点后，才能被认为完全正常运行。在此之前的所有输出都应被视为模型预热和学习过程的一部分。


---
5.  **数值稳定性与溢出问题**
    *   `ExponentialWeighting.weight(t)` 中 `t` 过大（特别是 `time_decay` 设置过大时）是否会导致 `e^(alpha * t)` 溢出？


**我们在 `ED-RRCF` 算法讨论中探讨的问题归纳**

1.  **`pysad_rrcf.py` 与 `rrcf_edr.py` 实现差异与行为一致性问题**
    *   `pysad_rrcf.py` 原始实现中，评分 (`score_partial`) 和更新 (`fit_partial`) 逻辑与 `rrcf_edr.py` 的“更新并评分”模式不符。
    *   `_SingleTree.update` 方法中，`L` 变量的用法与 `rrcf_edr.py` 不一致，且存在冗余。
    *   `wi` (新点权重) 在 `i >= time_decay` 阶段的计算方式与 `rrcf_edr.py` 不一致 (`weight(time_decay)` vs `weight(time_decay - 1)`)。

2.  **`PySAD` `BaseModel` API 兼容性问题**
    *   是否能直接实现 `fit_score_partial` 而不实现 `fit_partial` 和 `score_partial`？（结论：不符合 `BaseModel` 接口规范）

3.  **模型运行阶段与稳定性问题**
    *   模型从接收第一个样本点到完全稳定输出可靠结果，分为哪些时间阶段？
    *   何时才能算作“正常运行”？（涉及到 `shingle_size`、`tree_size`、`time_decay`、`calibrator_window_size` 的综合考量）
    *   如何用 Mermaid 图清晰地表示这些阶段和流程？

4.  **参数的深层语义与优化问题**
    *   **`time_decay` 参数的必要性**：它是否可以被 `e` 和 `alpha` 替代？与“历史窗口”概念的对齐？
    *   **`time_decay` 与 `tree_size` 的关系**：`time_decay` 比 `tree_size` 小是否无妨？对算法行为有何影响？
    *   **`e` 和 `alpha` 与“历史窗口”的对齐**：如何通过这两个参数控制模型的“记忆长度”？
    *   **`P` 值的确定**：在 `alpha = -ln(P) / H` 公式中，`P` (权重衰减比例) 如何选择？

5.  **数值稳定性与溢出问题**
    *   `ExponentialWeighting.weight(t)` 中 `t` 过大（特别是 `time_decay` 设置过大时）是否会导致 `e^(alpha * t)` 溢出？
    *   这种溢出对蓄水池采样行为有何影响？
    *   如何通过截断机制避免溢出？截断机制本身对采样的影响是什么？

6.  **传统 `RRCF` 在流式数据中的局限性**
    *   传统 `RRCF` 的无偏均匀采样机制，在概念漂移普遍存在的流式环境中，为何成为其核心缺陷？
    *   如何更深刻、直观地阐述传统 `RRCF` 理论前提与流式应用需求之间的不一致性？

---
1.  **阶段 1: Shingle 缓冲区填充 (0 <= t < S-1)**
2.  **阶段 2: 树填充 / 初始学习 (S-1 <= t < S-1 + T)**
3.  **阶段 3: 满树操作与衰减预热 (S-1 + T <= t < S-1 + D)**
4.  **阶段 4: 满树操作与完全指数衰减 (t >= S-1 + D)**
5.  **阶段 5: 阈值校准器填充 (t < S-1 + W_C)**
6.  **阶段 6: 完全运行 (t >= S-1 + W_C)**

---
- $H$, $O$, $C$
- $H_2O$, $CO_2$
- $CH_3CH_2OH$, $CH_3COOH$
```
