### PR TITLE
fix: handle custom `code_block` component when `stream-monaco` is not…

### DIFF
--- a/src/components/CodeBlockNode/CodeBlockNode.vue
+++ b/src/components/CodeBlockNode/CodeBlockNode.vue
@@ -8,9 +8,9 @@ import { useSafeI18n } from '../../composables/useSafeI18n'
 import { hideTooltip, showTooltipForAnchor } from '../../composables/useSingletonTooltip'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { getLanguageIcon, languageMap } from '../../utils'
+import { getCustomNodeComponents } from '../../utils/nodeComponents'
 import { safeCancelRaf, safeRaf } from '../../utils/safeRaf'
 import PreCodeNode from '../PreCodeNode'
-import { getUseMonaco } from './monaco'
 
 const props = withDefaults(
   defineProps<CodeBlockNodeProps>(),
@@ -97,6 +97,13 @@ const usePreCodeRender = ref(false)
 if (typeof window !== 'undefined') {
   ;(async () => {
     try {
+      const customComponent = getCustomNodeComponents(props.customId)
+      if (customComponent.code_block) {
+        usePreCodeRender.value = false
+        return
+      }
+
+      const { getUseMonaco } = await import('./monaco')
       const mod = await getUseMonaco()
       // If mod is null, stream-monaco is not available
       if (!mod) {


### PR DESCRIPTION
## Problem

When using `setCustomComponents` to fully customize code block rendering, users may choose not to install `stream-monaco` since Monaco can be too heavy for many scenarios. However, the current logic causes `getUseMonaco()` import errors to fallback to `PreCodeNode`, which bypasses the custom component entirely.

## Solution

Skip Monaco editor initialization when a custom `code_block` component is detected, ensuring custom components work without requiring `stream-monaco` installation.

Or maybe we should turn the Monaco code block into an async component, so that the method won’t be executed immediately and the issue may can be resolved.