### PR TITLE
fix: math formula in the Playground examples fixed

### DIFF
--- a/playground/src/const/markdown.ts
+++ b/playground/src/const/markdown.ts
@@ -53,71 +53,75 @@ https://github.com/Simon-He95/vue-markdown-render
 
 ---
 
+## 0. 薛定谔方程（量子力学）
+$$i\\hbar \\frac{\\partial}{\\partial t} \\Psi(\\mathbf{r},t) = \\left[ -\\frac{\\hbar^2}{2m} \\nabla^2 + V(\\mathbf{r},t) \\right] \\Psi(\\mathbf{r},t)$$
+
+
 ## 1. 泰勒公式（Taylor's Formula）
 
-### 一般形式（在点 \(x = a\) 处展开）：
-\[
+### 一般形式（在点 \\(x = a\\) 处展开）：
+\\[
 f(x) = f(a) + f'(a)(x-a) + \frac{f''(a)}{2!}(x-a)^2 + \frac{f'''(a)}{3!}(x-a)^3 + \cdots + \frac{f^{(n)}(a)}{n!}(x-a)^n + R_n(x)
-\]
+\\]
 
 其中：
-- \(f^{(k)}(a)\) 是 \(f(x)\) 在 \(x=a\) 处的 \(k\) 阶导数
-- \(R_n(x)\) 是余项，常见形式有拉格朗日余项：
-\[
+- \\(f^{(k)}(a)\\) 是 \\(f(x)\\) 在 \\(x=a\\) 处的 \\(k\\) 阶导数
+- \\(R_n(x)\\) 是余项，常见形式有拉格朗日余项：
+\\[
 R_n(x) = \frac{f^{(n+1)}(xi)}{(n+1)!}(x-a)^{n+1}, \quad xi \text{ 在 } a \text{ 和 } x \text{ 之间}
-\]
+\\]
 
 ---
 
-## 2. 麦克劳林公式（Maclaurin's Formula，即 \(a=0\) 时的泰勒公式）：
-\[
+## 2. 麦克劳林公式（Maclaurin's Formula，即 \\(a=0\\) 时的泰勒公式）：
+\\[
 f(x) = f(0) + f'(0)x + \frac{f''(0)}{2!}x^2 + \frac{f'''(0)}{3!}x^3 + \cdots + \frac{f^{(n)}(0)}{n!}x^n + R_n(x)
-\]
+\\]
 
 ---
 
 ## 3. 常见函数的麦克劳林展开（前几项）
 
 - **指数函数**：
-\[
+\\[
 e^x = 1 + x + \frac{x^2}{2!} + \frac{x^3}{3!} + \cdots + \frac{x^n}{n!} + \cdots, \quad x \in \mathbb{R}
-\]
+\\]
 
 - **正弦函数**：
-\[
+\\[
 \sin x = x - \frac{x^3}{3!} + \frac{x^5}{5!} - \frac{x^7}{7!} + \cdots + (-1)^n \frac{x^{2n+1}}{(2n+1)!} + \cdots
-\]
+\\]
 
 - **余弦函数**：
-\[
+\\[
 \cos x = 1 - \frac{x^2}{2!} + \frac{x^4}{4!} - \frac{x^6}{6!} + \cdots + (-1)^n \frac{x^{2n}}{(2n)!} + \cdots
-\]
+\\]
 
-- **自然对数**（在 \(x=0\) 附近）：
-\[
+- **自然对数**（在 \\(x=0\\) 附近）：
+\\[
 \ln(1+x) = x - \frac{x^2}{2} + \frac{x^3}{3} - \frac{x^4}{4} + \cdots + (-1)^{n-1} \frac{x^n}{n} + \cdots, \quad -1 < x \le 1
-\]
+\\]
 
-- **二项式展开**（\( (1+x)^m \)，\(m\) 为实数）：
-\[
+- **二项式展开**（\\( (1+x)^m \\)，\\(m\\) 为实数）：
+\\[
 (1+x)^m = 1 + mx + \frac{m(m-1)}{2!}x^2 + \frac{m(m-1)(m-2)}{3!}x^3 + \cdots, \quad |x| < 1
-\]
+\\]
 
 - **矩阵**：
-\[
+\\[
 \begin{bmatrix}
 2x_2 - 8x_3 = 8 \\
 5x_1 - 5x_3 = 10
 \end{bmatrix}
-\]
+\\]
 
 - **公式**
 
 
 - **代入数据**
-   \[
+   \\[
    \frac{363}{15,\!135} \times 100\% = 2.398\%
-   \]
+   \\]
 
 - **计算工具验证**
    通过数学计算工具确认结果：
@@ -393,32 +397,32 @@ graph TD
 ---
 # 复杂数学公式
 
-### 1. **理解 \(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 的含义**
-   - \(\boldsymbol{\alpha}\) 和 \(\boldsymbol{\beta}\) 是三维列向量，因此 \(\boldsymbol{\alpha}^T \boldsymbol{\beta}\) 表示它们的点积（内积）。
-   - \(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 意味着向量 \(\boldsymbol{\alpha}\) 和 \(\boldsymbol{\beta}\) 正交（即垂直），因为点积为零表示它们之间的夹角为 90 度。
+### 1. **理解 \\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 的含义**
+   - \\(\boldsymbol{\alpha}\\) 和 \\(\boldsymbol{\beta}\\) 是三维列向量，因此 \\(\boldsymbol{\alpha}^T \boldsymbol{\beta}\\) 表示它们的点积（内积）。
+   - \\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 意味着向量 \\(\boldsymbol{\alpha}\\) 和 \\(\boldsymbol{\beta}\\) 正交（即垂直），因为点积为零表示它们之间的夹角为 90 度。
 
 ### 2. **正交补空间的概念**
-   - 在线性代数中，对于一个子空间 \(W\)，它的正交补空间（记为 \(W^\perp\)）定义为所有与 \(W\) 中每个向量正交的向量的集合。即：
-     \[
+   - 在线性代数中，对于一个子空间 \\(W\\)，它的正交补空间（记为 \\(W^\perp\\)）定义为所有与 \\(W\\) 中每个向量正交的向量的集合。即：
+     \\[
      W^\perp = \{ \mathbf{v} \in \mathbb{R}^3 \mid \mathbf{v} \cdot \mathbf{w} = 0 \text{ 对于所有 } \mathbf{w} \in W \}
-     \]
-   - 例如，如果 \(W\) 是由一个向量 \(\boldsymbol{\alpha}\) 张成的一维子空间（即 \(W = \operatorname{span}\{\boldsymbol{\alpha}\}\)），那么 \(W^\perp\) 就是所有与 \(\boldsymbol{\alpha}\) 正交的向量构成的二维平面。
+     \\]
+   - 例如，如果 \\(W\\) 是由一个向量 \\(\boldsymbol{\alpha}\\) 张成的一维子空间（即 \\(W = \operatorname{span}\{\boldsymbol{\alpha}\}\\)），那么 \\(W^\perp\\) 就是所有与 \\(\boldsymbol{\alpha}\\) 正交的向量构成的二维平面。
 
-### 3. **\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 与正交补空间的联系**
-   - 当 \(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 时，这意味着：
-     - \(\boldsymbol{\beta}\) 属于 \(\operatorname{span}\{\boldsymbol{\alpha}\}\) 的正交补空间，即 \(\boldsymbol{\beta} \in (\operatorname{span}\{\boldsymbol{\alpha}\})^\perp\)。
-     - 同样，\(\boldsymbol{\alpha}\) 也属于 \(\operatorname{span}\{\boldsymbol{\beta}\}\) 的正交补空间，即 \(\boldsymbol{\alpha} \in (\operatorname{span}\{\boldsymbol{\beta}\})^\perp\)。
-   - 换句话说，\(\boldsymbol{\beta}\) 与 \(\boldsymbol{\alpha}\) 张成的直线正交，因此 \(\boldsymbol{\beta}\) 位于该直线的垂直平面（即正交补空间）上。反之亦然。
+### 3. **\\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 与正交补空间的联系**
+   - 当 \\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 时，这意味着：
+     - \\(\boldsymbol{\beta}\\) 属于 \\(\operatorname{span}\{\boldsymbol{\alpha}\}\\) 的正交补空间，即 \\(\boldsymbol{\beta} \in (\operatorname{span}\{\boldsymbol{\alpha}\})^\perp\\)。
+     - 同样，\\(\boldsymbol{\alpha}\\) 也属于 \\(\operatorname{span}\{\boldsymbol{\beta}\}\\) 的正交补空间，即 \\(\boldsymbol{\alpha} \in (\operatorname{span}\{\boldsymbol{\beta}\})^\perp\\)。
+   - 换句话说，\\(\boldsymbol{\beta}\\) 与 \\(\boldsymbol{\alpha}\\) 张成的直线正交，因此 \\(\boldsymbol{\beta}\\) 位于该直线的垂直平面（即正交补空间）上。反之亦然。
 
 ### 4. **在三维空间中的几何意义**
-   - 在三维空间中，如果 \(\boldsymbol{\alpha}\) 是一个非零向量，那么 \(\operatorname{span}\{\boldsymbol{\alpha}\}\) 是一条通过原点的直线，而它的正交补空间 \((\operatorname{span}\{\boldsymbol{\alpha}\})^\perp\) 是一个通过原点且与该直线垂直的平面。
-   - \(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 表示 \(\boldsymbol{\beta}\) 位于这个垂直平面上。同样，如果 \(\boldsymbol{\beta}\) 非零，那么 \(\boldsymbol{\alpha}\) 也位于与 \(\boldsymbol{\beta}\) 垂直的平面上。
+   - 在三维空间中，如果 \\(\boldsymbol{\alpha}\\) 是一个非零向量，那么 \\(\operatorname{span}\{\boldsymbol{\alpha}\}\\) 是一条通过原点的直线，而它的正交补空间 \\((\operatorname{span}\{\boldsymbol{\alpha}\})^\perp\\) 是一个通过原点且与该直线垂直的平面。
+   - \\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 表示 \\(\boldsymbol{\beta}\\) 位于这个垂直平面上。同样，如果 \\(\boldsymbol{\beta}\\) 非零，那么 \\(\boldsymbol{\alpha}\\) 也位于与 \\(\boldsymbol{\beta}\\) 垂直的平面上。
 
 ### 5. **推广到更一般的情况**
-   - 如果考虑多个向量，正交补空间的概念可以扩展。例如，如果有一组向量 \(\{\boldsymbol{\alpha}_1, \boldsymbol{\alpha}_2, \ldots, \boldsymbol{\alpha}_k\}\)，那么它们的张成子空间 \(W = \operatorname{span}\{\boldsymbol{\alpha}_1, \ldots, \boldsymbol{\alpha}_k\}\) 的正交补空间 \(W^\perp\) 包含所有与这些向量正交的向量。
-   - 在这种情况下，\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 可以看作 \(\boldsymbol{\beta}\) 与 \(W\) 正交的一个特例（当 \(W\) 只由 \(\boldsymbol{\alpha}\) 张成时）。
+   - 如果考虑多个向量，正交补空间的概念可以扩展。例如，如果有一组向量 \\(\{\boldsymbol{\alpha}_1, \boldsymbol{\alpha}_2, \ldots, \boldsymbol{\alpha}_k\}\\)，那么它们的张成子空间 \\(W = \operatorname{span}\{\boldsymbol{\alpha}_1, \ldots, \boldsymbol{\alpha}_k\}\\) 的正交补空间 \\(W^\perp\\) 包含所有与这些向量正交的向量。
+   - 在这种情况下，\\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 可以看作 \\(\boldsymbol{\beta}\\) 与 \\(W\\) 正交的一个特例（当 \\(W\\) 只由 \\(\boldsymbol{\alpha}\\) 张成时）。
 
-总之，\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\) 直接体现了正交补空间的关系：它表明一个向量属于另一个向量张成子空间的正交补空间。如果你有更多向量或子空间，这种联系可以进一步深化。
+总之，\\(\boldsymbol{\alpha}^T \boldsymbol{\beta} = 0\\) 直接体现了正交补空间的关系：它表明一个向量属于另一个向量张成子空间的正交补空间。如果你有更多向量或子空间，这种联系可以进一步深化。
 
 **示例：** emm\`1-(5)\`、\`3-(3)\`、\`3-(4)\` complex test \`1-(4)\`“heiheihei”中，hello world。
 `


### PR DESCRIPTION
fix: math formula in the Playground examples fixed.

使用\\(...\\)、\\[...\\]，而非(...)、[...]，以反斜杠显式区分数学公式与普通括号文本。