### PR TITLE
fix: Component StrongNode will call its own but dose not import self

### DIFF
--- a/src/components/StrongNode/StrongNode.vue
+++ b/src/components/StrongNode/StrongNode.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getCustomNodeComponents } from '../../utils/nodeComponents'
+import StrongNode from '.'
 import EmojiNode from '../EmojiNode'
 import EmphasisNode from '../EmphasisNode'
 import FootnoteReferenceNode from '../FootnoteReferenceNode'
@@ -45,6 +46,7 @@ const nodeComponents = {
   footnote_reference: FootnoteReferenceNode,
   math_inline: MathInlineNodeAsync,
   reference: ReferenceNode,
+  strong: StrongNode,
   // 添加其他内联元素组件
   ...getCustomNodeComponents(props.customId),
 }


### PR DESCRIPTION
#164 markdown-it-ts解析"__aaa__"并不会只生成一层strong，所以造成了页面没数据的情况。但是issue中提的全文复制过去又会出现将__变成加粗的情况，我发现并不止markdown-it-ts解析会出现这种情况，哪怕掘金都会出现这种加粗的情况，我觉得可能是写的不规范导致的