### PR TITLE
[markstream-react]: set suppressErrorRendering to prevent error DOM injection

### DIFF
--- a/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
+++ b/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
@@ -234,11 +234,13 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
       return {
         startOnLoad: false,
         securityLevel: 'loose',
+        suppressErrorRendering: true,
       }
     }
     return {
       startOnLoad: false,
       securityLevel: 'strict',
+      suppressErrorRendering: true,
       dompurifyConfig: DOMPURIFY_CONFIG,
       flowchart: { htmlLabels: false },
     }


### PR DESCRIPTION
<img width="1371" height="1147" alt="image" src="https://github.com/user-attachments/assets/718b99b6-4196-4ecc-a496-b2adab76d7f6" />
