### PR TITLE
fix(markstream-react): Restore cached SVG when switching from source …

### DIFF
--- a/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
+++ b/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
@@ -357,6 +357,14 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
     }
   }, [])
 
+  // Restore cached SVG when switching from source to preview
+  useLayoutEffect(() => {
+    if (!showSource && contentRef.current && svgCacheRef.current[theme]) {
+      contentRef.current.innerHTML = svgCacheRef.current[theme]!
+      updateContainerHeight()
+    }
+  }, [showSource, theme, updateContainerHeight])
+
   const renderFull = useCallback(async (code: string, t: Theme, signal?: AbortSignal) => {
     if (!mermaidRef.current || !contentRef.current)
       return false
@@ -599,13 +607,6 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
       setZoom(saved.zoom)
       setTranslate({ x: saved.translateX, y: saved.translateY })
       setContainerHeight(saved.containerHeight)
-      if (hasRenderedOnceRef.current && svgCacheRef.current[theme] && contentRef.current) {
-        contentRef.current.innerHTML = svgCacheRef.current[theme]!
-        updateContainerHeight()
-      }
-      else {
-        progressiveRender(baseFixedCode)
-      }
     }
     else {
       savedTransformRef.current = {


### PR DESCRIPTION
 ### 问题

  当用户从 Mermaid 组件的 source 面板切换回 preview 面板时，图表无法显示，导致空白页面。

###  原因

  在 `handleSwitchMode` 事件回调中尝试恢复缓存时，`contentRef.current` 为 null，因为 React 状态更新是异步的，`setShowSource(false)` 后组件需要重新渲染才能更新 DOM。