### PR TITLE
#288 React 框架、mermaid 流程在折叠后并展开、会导致流程图消失

### DIFF
--- a/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
+++ b/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
@@ -968,7 +968,7 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
         )}
       >
         {header}
-        <div ref={modeContainerRef} style={{ display: isCollapsed ? 'none' : 'block' }}>
+        <div ref={modeContainerRef} style={{ display: isCollapsed ? 'none' : '' }}>
           {body}
         </div>
       </div>


### PR DESCRIPTION
## 相关问题

#288 

## 使用 display 来控制、当折叠时隐藏容器、展开时清空 display、防止样式过度干扰

![录屏_20260202_192340](https://github.com/user-attachments/assets/87ed738f-64dc-4685-8d9b-b7cbe037e8c9)

修复后的正常情况