### PR TITLE
fix#290：React 中、修复同时渲染大量内容时、mermaid 流程图可以正常渲染

### DIFF
--- a/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
+++ b/packages/markstream-react/src/components/MermaidBlockNode/MermaidBlockNode.tsx
@@ -464,10 +464,12 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
   useEffect(() => {
     if (!viewportReady || showSource || isCollapsed)
       return
+    if (!mermaidRef.current)
+      return
     const controller = new AbortController()
     progressiveRender(baseFixedCode, controller.signal)
     return () => controller.abort()
-  }, [baseFixedCode, isCollapsed, progressiveRender, showSource, viewportReady])
+  }, [baseFixedCode, isCollapsed, progressiveRender, showSource, viewportReady, mermaidAvailable])
 
   const handleTooltip = useCallback((event: React.MouseEvent<HTMLElement>, text: string) => {
     const origin = { x: event.clientX, y: event.clientY }
@@ -722,13 +724,13 @@ export function MermaidBlockNode(rawProps: MermaidBlockNodeProps & MermaidBlockN
           </div>
         </div>
       )}
-      <div
-        ref={containerRef}
-        className={clsx(
-          'min-h-[360px] relative transition-all duration-100 overflow-hidden block',
-          props.isDark ? 'bg-gray-900' : 'bg-gray-50',
-        )}
-        style={{ height: containerHeight, maxHeight: props.maxHeight ?? undefined }}
+        <div
+          ref={containerRef}
+          className={clsx(
+            'min-h-[360px] relative transition-all duration-100 overflow-hidden block',
+            props.isDark ? 'bg-gray-900' : 'bg-gray-50',
+          )}
+          style={{ height: containerHeight, maxHeight: props.maxHeight ?? undefined }}
         onWheel={handleWheel}
         onMouseDown={(event) => {
           if (event.button !== 0)


### PR DESCRIPTION
# 相关问题

#290 

# 修复后的情况

![录屏_20260203_174440](https://github.com/user-attachments/assets/f5e1d0b2-7480-49e4-a949-4fa840fba76f)
