### PR TITLE
fix(container): preserve original markdown in vm_container raw

### DIFF
--- a/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
+++ b/packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts
@@ -156,7 +156,8 @@ function parseVmrContainer(
   }
   raw += '\n'
   if (children.length > 0) {
-    raw += children.map(c => c.raw).join('\n')
+    // Prefer original Markdown (openToken.raw); rebuilding from tokens may lose formatting.
+    raw += openToken.raw ?? children.map(c => c.raw).join('\n')
     raw += '\n'
   }
   raw += ':::'

--- a/packages/markdown-parser/src/plugins/containers.ts
+++ b/packages/markdown-parser/src/plugins/containers.ts
@@ -316,6 +316,15 @@ export function applyContainers(md: MarkdownIt) {
           innerSrc += '\n'
         if (!innerSrc.endsWith('\n\n'))
           innerSrc += '\n'
+
+        // The last token should be the current vm_container_open token
+        const prevToken = s.tokens[s.tokens.length - 1]
+
+        // Save the inner Markdown content as raw
+        if (prevToken) {
+          prevToken.raw = innerSrc
+        }
+
         const innerTokens: any[] = []
         // Use the same env as the parent block parser to ensure all block rules are available
         s.md.block.parse(innerSrc, s.md, s.env, innerTokens)

--- a/test/plugins/containers-plugin.test.ts
+++ b/test/plugins/containers-plugin.test.ts
@@ -1,4 +1,4 @@
-import { getMarkdown } from 'stream-markdown-parser'
+import { getMarkdown, parseMarkdownToStructure } from 'stream-markdown-parser'
 import { describe, expect, it } from 'vitest'
 
 describe('containers plugin', () => {
@@ -27,4 +27,19 @@ describe('containers plugin', () => {
     // contains paragraph with content
     expect(html).toContain('<p>这是一个警告块。</p>')
   })
+
+  it('preserves original markdown inside container', () => {
+  const md = getMarkdown('t')
+  const content = `::: note-test \n# head text\n:::`
+  const tokens = parseMarkdownToStructure(content, md)
+  
+  // the raw should contain the markdown `# head text`
+  expect(tokens).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        raw: expect.stringContaining('#')
+      })
+    ])
+  )
+})
 })


### PR DESCRIPTION
## Summary

Fix an issue where the vm_container token did not preserve the original Markdown content.

## Changes

-packages/markdown-parser/src/plugins/containers.ts
-packages/markdown-parser/src/parser/node-parsers/block-token-parser.ts

## Input
```
::: vm_container
# 头部文本
:::
```

## Output
```
const tokens = parseMarkdownToStructure
[ 
 {
  raw:'# 头部文本'
 }
]
```
