### PR TITLE
Fix/fix issue 386 inline sup reference

### DIFF
--- a/packages/markdown-parser/src/index.ts
+++ b/packages/markdown-parser/src/index.ts
@@ -267,6 +267,7 @@ export function getMarkdown(msgId: string = `editor-${Date.now()}`, options: Get
       const token = s.push('reference', 'span', 0)
       token.content = id
       token.markup = match[0]
+      token.raw = match[0]
     }
     s.pos += match[0].length
     return true

--- a/packages/markdown-parser/src/parser/inline-parsers/html-inline-code-parser.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/html-inline-code-parser.ts
@@ -99,6 +99,49 @@ function stringifyTokens(tokens: MarkdownToken[]) {
   return tokens.map(tokenToRaw).join('')
 }
 
+function normalizeStandardHtmlChildren(children: ParsedNode[]) {
+  const normalized: ParsedNode[] = []
+
+  const pushText = (rawText: string) => {
+    const text = String(rawText ?? '')
+    if (!text)
+      return
+    const last = normalized[normalized.length - 1] as ParsedNode | undefined
+    if (last?.type === 'text') {
+      ; (last as any).content = String((last as any).content ?? '') + text
+      ; (last as any).raw = String((last as any).raw ?? '') + text
+      return
+    }
+    normalized.push({
+      type: 'text',
+      content: text,
+      raw: text,
+    } as ParsedNode)
+  }
+
+  for (const child of children) {
+    if (!child)
+      continue
+
+    if (child.type === 'reference' || child.type === 'footnote_reference') {
+      pushText(String((child as any).raw ?? ''))
+      continue
+    }
+
+    if (Array.isArray((child as any).children)) {
+      normalized.push({
+        ...(child as any),
+        children: normalizeStandardHtmlChildren(((child as any).children ?? []) as ParsedNode[]),
+      } as ParsedNode)
+      continue
+    }
+
+    normalized.push(child)
+  }
+
+  return normalized
+}
+
 function findMatchingClosing(tokens: MarkdownToken[], startIndex: number, tag: string) {
   let depth = 0
   for (let idx = startIndex; idx < tokens.length; idx++) {
@@ -228,10 +271,11 @@ export function parseHtmlInlineCodeToken(
     const children = innerTokens.length
       ? parseInlineTokens(innerTokens, raw, pPreToken, options)
       : []
+    const normalizedChildren = normalizeStandardHtmlChildren(children)
     const textContent = innerTokens.length ? stringifyTokens(innerTokens) : href || ''
 
-    if (!children.length && textContent) {
-      children.push({
+    if (!normalizedChildren.length && textContent) {
+      normalizedChildren.push({
         type: 'text',
         content: textContent,
         raw: textContent,
@@ -245,7 +289,7 @@ export function parseHtmlInlineCodeToken(
         title,
         text: textContent,
         attrs: normalizedAttrs,
-        children,
+        children: normalizedChildren,
         loading: !fragment.closed,
         raw: fragment.html || code,
       } as ParsedNode,
@@ -274,10 +318,11 @@ export function parseHtmlInlineCodeToken(
     const children = fragment.innerTokens.length
       ? parseInlineTokens(fragment.innerTokens, raw, pPreToken, options)
       : []
+    const normalizedChildren = normalizeStandardHtmlChildren(children)
     return [
       {
         type: 'paragraph',
-        children,
+        children: normalizedChildren,
         raw: fragment.html,
       } as ParsedNode,
       fragment.nextIndex,
@@ -287,6 +332,7 @@ export function parseHtmlInlineCodeToken(
   const children = fragment.innerTokens.length
     ? parseInlineTokens(fragment.innerTokens, raw, pPreToken, options)
     : []
+  const normalizedChildren = normalizeStandardHtmlChildren(children)
 
   let content = fragment.html || code
   let loading = !fragment.closed
@@ -336,7 +382,7 @@ export function parseHtmlInlineCodeToken(
       tag,
       attrs,
       content,
-      children,
+      children: normalizedChildren,
       raw: content,
       loading,
       autoClosed,

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -24,7 +24,7 @@ import { parseTextToken } from './text-parser'
 const STRONG_PAIR_RE = /\*\*([\s\S]*?)\*\*/
 const STRIKETHROUGH_RE = /[^~]*~{2,}[^~]+/
 const HAS_STRONG_RE = /\*\*/
-const INLINE_REPARSE_MARKER_RE = /\*\*\*|___|\*\*|__|\*|_|~~/
+const INLINE_REPARSE_MARKER_RE = /[[_*^~]/
 const ESCAPED_PUNCTUATION_RE = /\\([\\()[\]`$|*_\-!])/g
 const ESCAPABLE_PUNCTUATION = new Set(['\\', '(', ')', '[', ']', '`', '$', '|', '*', '_', '-', '!'])
 

--- a/packages/markdown-parser/src/parser/inline-parsers/index.ts
+++ b/packages/markdown-parser/src/parser/inline-parsers/index.ts
@@ -596,14 +596,14 @@ export function parseInlineTokens(
 
   function tryReparseCollapsedInlineText(rawContent: string): ParsedNode[] | null {
     const md = (options as any)?.__markdownIt as MarkdownIt | undefined
-    if (!md || !options?.final)
+    if (!md)
       return null
     if (tokens.length <= 1 || !tokens.some(token => token?.type === 'math_inline'))
       return null
     if (!INLINE_REPARSE_MARKER_RE.test(rawContent))
       return null
 
-    const reparsed = md.parseInline(rawContent, { __markstreamFinal: true }) as unknown as MarkdownToken[]
+    const reparsed = md.parseInline(rawContent, { __markstreamFinal: !!options?.final }) as unknown as MarkdownToken[]
     if (!Array.isArray(reparsed) || reparsed.length === 0)
       return null
 

--- a/packages/markdown-parser/src/plugins/math.ts
+++ b/packages/markdown-parser/src/plugins/math.ts
@@ -435,6 +435,24 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
     const strict = !!mathOpts?.strictDelimiters
     const allowLoading = !s?.env?.__markstreamFinal
 
+    const preserveSpacesBeforeLineBreak = (src: string, start: number) => {
+      let end = start
+      while (end < src.length && (src[end] === ' ' || src[end] === '\t'))
+        end++
+
+      if (end === start)
+        return start
+
+      const hitsLineBreak = src[end] === '\n' || (src[end] === '\r' && src[end + 1] === '\n')
+      if (!hitsLineBreak)
+        return start
+
+      const text = src.slice(start, end)
+      const token = s.push('text', '', 0)
+      token.content = text
+      return end
+    }
+
     if (/^\*[^*]+/.test(s.src)) {
       return false
     }
@@ -852,12 +870,15 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
             // Always advance cursor past the math span; otherwise when the math
             // is at end-of-line (raw === ''), we'd loop forever on the same opener.
             // 这里的 raw 可能还会有 math_inline, 应该交给后续的规则处理，直接 s.pos 到当前位置
-            s.pos = endIdx + close.length
+            s.pos = preserveSpacesBeforeLineBreak(src, endIdx + close.length)
             searchPos = s.pos
             preMathPos = searchPos
             if (!isBeforeClose)
               s.push('strong_close', '', 0)
-            continue
+            // Leave the remaining inline suffix to markdown-it so later rules
+            // (for example superscript, footnotes, or strong/emphasis) can
+            // tokenize it normally instead of being collapsed into plain text.
+            return true
           }
           else {
             const token = s.push('math_inline', 'math', 0)
@@ -868,9 +889,14 @@ export function applyMath(md: MarkdownIt, mathOpts?: MathOptions) {
           }
         }
 
-        searchPos = endIdx + close.length
+        searchPos = preserveSpacesBeforeLineBreak(src, endIdx + close.length)
         preMathPos = searchPos
         s.pos = searchPos
+        // Do not consume the trailing suffix here. Returning now lets the
+        // inline parser continue from the end of the math token so adjacent
+        // markdown like `^[1]^`, `[^1]`, or `**strong**` is still parsed by
+        // the normal rules.
+        return true
       }
 
       if (foundAny) {

--- a/packages/markdown-parser/test/issue-386-inline-math-superscript-reference.test.ts
+++ b/packages/markdown-parser/test/issue-386-inline-math-superscript-reference.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { getMarkdown, parseMarkdownToStructure } from '../src'
+
+function parse(markdown: string) {
+  const md = getMarkdown('issue-386')
+  return parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+}
+
+function collectByType(value: any, targetType: string): any[] {
+  const out: any[] = []
+  const walk = (node: any) => {
+    if (!node)
+      return
+    if (Array.isArray(node)) {
+      node.forEach(walk)
+      return
+    }
+    if (node.type === targetType)
+      out.push(node)
+    if (Array.isArray(node.children))
+      node.children.forEach(walk)
+    if (Array.isArray(node.items))
+      node.items.forEach(walk)
+  }
+  walk(value)
+  return out
+}
+
+describe('issue #386 inline math suffix regressions', () => {
+  it('keeps superscript syntax immediately after inline math', () => {
+    const nodes = parse('$2.897771955 times 10^{-3}text{m·K}$^[1]^')
+    const paragraph = nodes[0] as any
+
+    expect(paragraph?.type).toBe('paragraph')
+    expect(paragraph?.children?.map((child: any) => child.type)).toEqual([
+      'math_inline',
+      'superscript',
+    ])
+    expect(paragraph?.children?.[1]?.children?.map((child: any) => child.content).join('')).toBe('[1]')
+
+    const textNodes = collectByType(paragraph, 'text')
+    expect(textNodes.some((node: any) => node.content === '^[1]^')).toBe(false)
+  })
+
+  it('keeps footnote references immediately after inline math', () => {
+    const nodes = parse('$x$[^1]\n\n[^1]: note')
+    const paragraph = nodes[0] as any
+
+    expect(paragraph?.type).toBe('paragraph')
+    expect(paragraph?.children?.map((child: any) => child.type)).toEqual([
+      'math_inline',
+      'footnote_reference',
+    ])
+    expect(paragraph?.children?.[1]?.id).toBe('1')
+
+    const footnotes = collectByType(nodes, 'footnote')
+    expect(footnotes).toHaveLength(1)
+    expect(footnotes[0]?.id).toBe('1')
+    expect(collectByType(footnotes[0], 'text').some((node: any) => node.content === 'note')).toBe(true)
+  })
+
+  it('preserves brackets inside sup html content', () => {
+    const nodes = parse('测试<sup>[3]</sup>。')
+    const paragraph = nodes[0] as any
+    const htmlInline = collectByType(paragraph, 'html_inline')[0] as any
+
+    expect(htmlInline).toBeDefined()
+    expect(htmlInline.content).toBe('<sup>[3]</sup>')
+    expect(htmlInline.children?.[0]?.type).toBe('reference')
+    expect(htmlInline.children?.[0]?.raw).toBe('[3]')
+  })
+
+  it('preserves brackets inside generic inline html content', () => {
+    const nodes = parse('<span>[3]</span>')
+    const paragraph = nodes[0] as any
+    const htmlInline = collectByType(paragraph, 'html_inline')[0] as any
+
+    expect(htmlInline).toBeDefined()
+    expect(htmlInline.content).toBe('<span>[3]</span>')
+    expect(htmlInline.children?.[0]?.type).toBe('reference')
+    expect(htmlInline.children?.[0]?.raw).toBe('[3]')
+  })
+})

--- a/packages/markdown-parser/test/issue-386-inline-math-superscript-reference.test.ts
+++ b/packages/markdown-parser/test/issue-386-inline-math-superscript-reference.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { getMarkdown, parseMarkdownToStructure } from '../src'
 
-function parse(markdown: string) {
+const REAL_WORLD_MULTILINE_INPUT = `$2.897771955 times 10^{-3}text{m·K}$^[1]^
+测试<sup>[3]</sup>。
+$x$^[1]^
+$x$ ^[1]^
+测试^[1]^
+$2.897771955 \\times 10^{-3}\\text{m·K}$^[1]^
+<sup>[1]</sup>
+测试<sup>[12]</sup>结束
+A<sup>[3]</sup>B
+$x$^[1]^
+测试^[1]^
+<sup>[3]</sup>
+测试<sup>[12]</sup>结束`
+
+function parse(markdown: string, final = true) {
   const md = getMarkdown('issue-386')
-  return parseMarkdownToStructure(markdown, md, { final: true }) as any[]
+  return parseMarkdownToStructure(markdown, md, { final }) as any[]
 }
 
 function collectByType(value: any, targetType: string): any[] {
@@ -27,8 +41,8 @@ function collectByType(value: any, targetType: string): any[] {
 }
 
 describe('issue #386 inline math suffix regressions', () => {
-  it('keeps superscript syntax immediately after inline math', () => {
-    const nodes = parse('$2.897771955 times 10^{-3}text{m·K}$^[1]^')
+  it.each([true, false])('keeps superscript syntax immediately after inline math when final=%s', (final) => {
+    const nodes = parse('$2.897771955 times 10^{-3}text{m·K}$^[1]^', final)
     const paragraph = nodes[0] as any
 
     expect(paragraph?.type).toBe('paragraph')
@@ -42,8 +56,8 @@ describe('issue #386 inline math suffix regressions', () => {
     expect(textNodes.some((node: any) => node.content === '^[1]^')).toBe(false)
   })
 
-  it('keeps footnote references immediately after inline math', () => {
-    const nodes = parse('$x$[^1]\n\n[^1]: note')
+  it.each([true, false])('keeps footnote references immediately after inline math when final=%s', (final) => {
+    const nodes = parse('$x$[^1]\n\n[^1]: note', final)
     const paragraph = nodes[0] as any
 
     expect(paragraph?.type).toBe('paragraph')
@@ -59,25 +73,64 @@ describe('issue #386 inline math suffix regressions', () => {
     expect(collectByType(footnotes[0], 'text').some((node: any) => node.content === 'note')).toBe(true)
   })
 
-  it('preserves brackets inside sup html content', () => {
-    const nodes = parse('测试<sup>[3]</sup>。')
+  it.each([true, false])('preserves brackets inside sup html content when final=%s', (final) => {
+    const nodes = parse('测试<sup>[3]</sup>。', final)
     const paragraph = nodes[0] as any
     const htmlInline = collectByType(paragraph, 'html_inline')[0] as any
 
     expect(htmlInline).toBeDefined()
     expect(htmlInline.content).toBe('<sup>[3]</sup>')
-    expect(htmlInline.children?.[0]?.type).toBe('reference')
-    expect(htmlInline.children?.[0]?.raw).toBe('[3]')
+    expect(htmlInline.children).toEqual([
+      {
+        type: 'text',
+        content: '[3]',
+        raw: '[3]',
+      },
+    ])
   })
 
-  it('preserves brackets inside generic inline html content', () => {
-    const nodes = parse('<span>[3]</span>')
+  it.each([true, false])('preserves brackets inside generic inline html content when final=%s', (final) => {
+    const nodes = parse('<span>[3]</span>', final)
     const paragraph = nodes[0] as any
     const htmlInline = collectByType(paragraph, 'html_inline')[0] as any
 
     expect(htmlInline).toBeDefined()
     expect(htmlInline.content).toBe('<span>[3]</span>')
-    expect(htmlInline.children?.[0]?.type).toBe('reference')
-    expect(htmlInline.children?.[0]?.raw).toBe('[3]')
+    expect(htmlInline.children).toEqual([
+      {
+        type: 'text',
+        content: '[3]',
+        raw: '[3]',
+      },
+    ])
+  })
+
+  it.each([true, false])('parses the real multiline issue-386 input without leaking raw superscript syntax when final=%s', (final) => {
+    const nodes = parse(REAL_WORLD_MULTILINE_INPUT, final)
+    const paragraph = nodes[0] as any
+    const superscripts = collectByType(paragraph, 'superscript')
+    const htmlInlineNodes = collectByType(paragraph, 'html_inline')
+    const textNodes = collectByType(paragraph, 'text')
+
+    expect(paragraph?.type).toBe('paragraph')
+    expect(superscripts).toHaveLength(7)
+    expect(superscripts.map((node: any) => node.children?.map((child: any) => child.content).join(''))).toEqual([
+      '[1]',
+      '[1]',
+      '[1]',
+      '[1]',
+      '[1]',
+      '[1]',
+      '[1]',
+    ])
+    expect(textNodes.some((node: any) => String(node.content).includes('^[1]^'))).toBe(false)
+    expect(htmlInlineNodes.map((node: any) => node.children?.map((child: any) => child.content).join(''))).toEqual([
+      '[3]',
+      '[1]',
+      '[12]',
+      '[3]',
+      '[3]',
+      '[12]',
+    ])
   })
 })

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -67,8 +67,13 @@ export default defineConfig(({ command }) => {
       },
     },
     optimizeDeps: {
-      // Keep dev linked to stream-monaco source so local edits hot-reload cleanly.
-      exclude: streamMonacoAlias === localStreamMonacoSource ? ['stream-monaco'] : [],
+      // Keep workspace-linked parser/runtime packages on source files in dev so
+      // fixes in the monorepo are reflected immediately instead of getting
+      // stuck behind Vite's optimized-deps cache.
+      exclude: [
+        'stream-markdown-parser',
+        ...(streamMonacoAlias === localStreamMonacoSource ? ['stream-monaco'] : []),
+      ],
     },
     plugins: [
       Vue({}),

--- a/test/issue386-renderer-regression.test.ts
+++ b/test/issue386-renderer-regression.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { mount } from '@vue/test-utils'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { flushAll } from './setup/flush-all'
+
+let MarkdownRender: any
+
+const REAL_WORLD_MULTILINE_INPUT = `$2.897771955 times 10^{-3}text{m·K}$^[1]^
+测试<sup>[3]</sup>。
+$x$^[1]^
+$x$ ^[1]^
+测试^[1]^
+$2.897771955 \\times 10^{-3}\\text{m·K}$^[1]^
+<sup>[1]</sup>
+测试<sup>[12]</sup>结束
+A<sup>[3]</sup>B
+$x$^[1]^
+测试^[1]^
+<sup>[3]</sup>
+测试<sup>[12]</sup>结束`
+
+async function mountMarkdown(markdown: string, extraProps: Record<string, unknown> = {}) {
+  const wrapper = mount(MarkdownRender, {
+    props: {
+      content: markdown,
+      ...extraProps,
+    },
+  })
+  await flushAll()
+  await flushAll()
+  return wrapper
+}
+
+describe('issue #386 renderer regressions', () => {
+  beforeAll(async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    MarkdownRender = (await import('../src/components/NodeRenderer')).default
+  })
+
+  it('renders bracketed superscript syntax from markdown content', async () => {
+    const wrapper = await mountMarkdown('测试^[1]^')
+
+    const sup = wrapper.find('sup.superscript-node')
+    expect(sup.exists()).toBe(true)
+    expect(sup.text()).toBe('[1]')
+    expect(wrapper.text()).not.toContain('^[1]^')
+  })
+
+  it('renders superscript syntax immediately after inline math', async () => {
+    const wrapper = await mountMarkdown('$x$^[1]^')
+
+    const sup = wrapper.find('sup.superscript-node')
+    expect(sup.exists()).toBe(true)
+    expect(sup.text()).toBe('[1]')
+    expect(wrapper.text()).not.toContain('^[1]^')
+  })
+
+  it('preserves brackets inside standard inline html tags', async () => {
+    const wrapper = await mountMarkdown('测试<sup>[3]</sup>。')
+
+    const sup = wrapper.find('.html-inline-node sup')
+    expect(sup.exists()).toBe(true)
+    expect(sup.text()).toBe('[3]')
+  })
+
+  it('renders the real multiline issue-386 input in streaming mode without leaking raw superscript syntax', async () => {
+    const wrapper = await mountMarkdown(REAL_WORLD_MULTILINE_INPUT, { final: false })
+
+    const superscripts = wrapper.findAll('sup.superscript-node')
+    const inlineHtmlSup = wrapper.findAll('.html-inline-node sup')
+
+    expect(superscripts).toHaveLength(7)
+    expect(superscripts.map(node => node.text())).toEqual(['[1]', '[1]', '[1]', '[1]', '[1]', '[1]', '[1]'])
+    expect(inlineHtmlSup.map(node => node.text())).toEqual(['[3]', '[1]', '[12]', '[3]', '[3]', '[12]'])
+    expect(wrapper.text()).not.toContain('^[1]^')
+  })
+})


### PR DESCRIPTION
Closes #386

## Summary

This fixes the regression reported in [#386](https://github.com/Simon-He95/markstream-vue/issues/386), where inline KaTeX content like `$...$` could break trailing `^[1]^` / `[1]` markers.
It also preserves bracketed text inside standard inline HTML such as `<sup>[1]</sup>` and adds regression coverage to keep parser and renderer behavior stable.

## Changes

- [x] Normalize standard inline HTML children so bracket text inside tags like `<sup>[1]</sup>` stays as literal text instead of being reparsed into broken reference nodes.
- [x] Adjust inline reparse handling around `math_inline` so trailing superscript / footnote markers after `$...$` are preserved.
- [x] Add parser and renderer regression tests for the original issue sample and related edge cases.
- [x] Update the playground parser bundling config so local repros use the latest parser changes during reproduction.

## Screenshots / Demo (if UI/behavior changes)

- [ ] Added GIF/screenshot
- [ ] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)
- Issue repro: [#386](https://github.com/Simon-He95/markstream-vue/issues/386)

## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test -- --run`
- [x] Build: `pnpm build` (library + CSS)
