### PR TITLE
fix: react live preview superscript

### DIFF
--- a/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
+++ b/packages/markstream-react/src/components/ParagraphNode/ParagraphNode.tsx
@@ -1,7 +1,9 @@
 import type { ParsedNode } from 'stream-markdown-parser'
 import type { NodeComponentProps } from '../../types/node-component'
 import React from 'react'
+import { getCustomNodeComponents } from '../../customComponents'
 import { BLOCK_LEVEL_TYPES, renderNodeChildren } from '../../renderers/renderChildren'
+import { isParagraphBreakingCustomHtmlNode } from '../../utils/customHtmlTag'
 
 function isWhitespaceTextNode(node: ParsedNode | null | undefined) {
   return node?.type === 'text' && String((node as any)?.content ?? '').trim() === ''
@@ -70,6 +72,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   const nodeChildren = node.children ?? []
+  const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
   const parts: React.ReactNode[] = []
   const inlineBuffer: ParsedNode[] = []
 
@@ -86,7 +89,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, customComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>

--- a/packages/markstream-react/src/customComponents.ts
+++ b/packages/markstream-react/src/customComponents.ts
@@ -1,6 +1,10 @@
 import type { ComponentType } from 'react'
 
-export type CustomComponentMap = Record<string, ComponentType<any>>
+export type CustomComponentDisplayMode = 'inline' | 'block'
+export type MarkstreamCustomComponent<P = any> = ComponentType<P> & {
+  markstreamDisplay?: CustomComponentDisplayMode
+}
+export type CustomComponentMap = Record<string, MarkstreamCustomComponent<any>>
 
 const GLOBAL_KEY = '__global__'
 
@@ -83,4 +87,16 @@ export function removeCustomComponents(id: string) {
 export function clearGlobalCustomComponents() {
   delete store.scopedComponents[GLOBAL_KEY]
   bumpRevision()
+}
+
+export function getCustomComponentDisplay(component: ComponentType<any> | null | undefined): CustomComponentDisplayMode | undefined {
+  return (component as MarkstreamCustomComponent<any> | null | undefined)?.markstreamDisplay
+}
+
+export function withMarkstreamComponentDisplay<T extends ComponentType<any>>(
+  component: T,
+  display: CustomComponentDisplayMode,
+) {
+  ;(component as MarkstreamCustomComponent<any>).markstreamDisplay = display
+  return component as T & { markstreamDisplay: CustomComponentDisplayMode }
 }

--- a/packages/markstream-react/src/index.ts
+++ b/packages/markstream-react/src/index.ts
@@ -57,9 +57,11 @@ export type { TooltipPlacement, TooltipProps } from './components/Tooltip/Toolti
 export { VmrContainerNode } from './components/VmrContainerNode/VmrContainerNode'
 export {
   clearGlobalCustomComponents,
+  getCustomComponentDisplay,
   getCustomNodeComponents,
   removeCustomComponents,
   setCustomComponents,
+  withMarkstreamComponentDisplay,
 } from './customComponents'
 export * from './i18n/useSafeI18n'
 export * from './renderers/renderNode'
@@ -92,6 +94,11 @@ export type { NodeComponentProps } from './types/node-component'
 export * from './utils/languageIcon'
 export * from './workers/katexWorkerClient'
 export * from './workers/mermaidWorkerClient'
+
+export type {
+  CustomComponentDisplayMode,
+  MarkstreamCustomComponent,
+} from './customComponents'
 
 export type CustomComponentMap = MarkstreamCustomComponentMap
 export type RenderContext = MarkstreamRenderContext

--- a/packages/markstream-react/src/renderers/renderChildren.tsx
+++ b/packages/markstream-react/src/renderers/renderChildren.tsx
@@ -6,7 +6,6 @@ export const BLOCK_LEVEL_TYPES = new Set([
   'table',
   'code_block',
   'html_block',
-  'html_inline',
   'blockquote',
   'list',
   'list_item',

--- a/packages/markstream-react/src/renderers/renderNode.tsx
+++ b/packages/markstream-react/src/renderers/renderNode.tsx
@@ -41,6 +41,7 @@ import { TextNode } from '../components/TextNode/TextNode'
 import { ThematicBreakNode } from '../components/ThematicBreakNode/ThematicBreakNode'
 import { VmrContainerNode } from '../components/VmrContainerNode/VmrContainerNode'
 import { getCustomNodeComponents } from '../customComponents'
+import { resolveCustomHtmlTag } from '../utils/customHtmlTag'
 import { normalizeLanguageIdentifier } from '../utils/languageIcon'
 import { renderNodeChildren } from './renderChildren'
 
@@ -138,12 +139,12 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
   }
 
   if (node.type === 'html_block' || node.type === 'html_inline') {
-    const tag = String((node as any).tag ?? '').trim().toLowerCase() || getHtmlTagFromContent((node as any).content)
+    const resolvedCustomTag = resolveCustomHtmlTag(node as any, customComponents as any, ctx.customHtmlTags)
+    const fallbackTag = String((node as any).tag ?? '').trim().toLowerCase() || getHtmlTagFromContent((node as any).content)
+    const tag = resolvedCustomTag?.tag ?? fallbackTag
     if (tag) {
-      const customForTag = (customComponents as Record<string, any>)[tag]
-      // Check if tag is whitelisted in customHtmlTags
-      const customHtmlTags = ctx.customHtmlTags ?? []
-      const isWhitelisted = customHtmlTags.some((t: string) => t.toLowerCase() === tag)
+      const customForTag = resolvedCustomTag?.component ?? (customComponents as Record<string, any>)[tag]
+      const isWhitelisted = resolvedCustomTag?.isWhitelisted ?? (ctx.customHtmlTags ?? []).some((t: string) => t.toLowerCase() === tag)
       if (isWhitelisted && customForTag) {
         const coerced = {
           ...(node as any),

--- a/packages/markstream-react/src/server-renderer/index.tsx
+++ b/packages/markstream-react/src/server-renderer/index.tsx
@@ -28,6 +28,7 @@ import {
 } from 'stream-markdown-parser'
 import { getCustomNodeComponents } from '../customComponents'
 import { BLOCK_LEVEL_TYPES, renderInline, renderNodeChildren, tokenAttrsToProps } from '../renderers/renderChildren'
+import { isParagraphBreakingCustomHtmlNode, resolveCustomHtmlTag } from '../utils/customHtmlTag'
 import { normalizeLanguageIdentifier } from '../utils/languageIcon'
 import { normalizeDomAttrs } from '../utils/htmlToReact'
 import { parseHtmlToReactNodes } from './html'
@@ -304,6 +305,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   const nodeChildren = node.children ?? []
+  const customComponents = ctx.customComponents ?? getCustomNodeComponents(ctx.customId)
   const parts: React.ReactNode[] = []
   const inlineBuffer: ParsedNode[] = []
 
@@ -320,7 +322,7 @@ export function ParagraphNode(props: NodeComponentProps<{ type: 'paragraph', chi
   }
 
   nodeChildren.forEach((child, childIndex) => {
-    if (BLOCK_LEVEL_TYPES.has(child.type)) {
+    if (BLOCK_LEVEL_TYPES.has(child.type) || isParagraphBreakingCustomHtmlNode(child, customComponents, ctx.customHtmlTags)) {
       flushInline()
       parts.push(
         <React.Fragment key={`${String(indexKey ?? 'paragraph')}-block-${childIndex}`}>
@@ -974,9 +976,10 @@ export function renderNode(node: ParsedNode, key: React.Key, ctx: RenderContext)
   }
 
   if (node.type === 'html_block' || node.type === 'html_inline') {
-    const tag = String((node as any).tag ?? '').trim().toLowerCase() || getHtmlTagFromContent((node as any).content)
-    const isWhitelisted = (ctx.customHtmlTags ?? []).some((t: string) => t.toLowerCase() === tag)
-    const customForTag = tag ? (customComponents as Record<string, any>)[tag] : null
+    const resolvedCustomTag = resolveCustomHtmlTag(node as any, customComponents as any, ctx.customHtmlTags)
+    const tag = resolvedCustomTag?.tag ?? ''
+    const isWhitelisted = resolvedCustomTag?.isWhitelisted ?? false
+    const customForTag = resolvedCustomTag?.component ?? null
     if (isWhitelisted && customForTag) {
       const coerced = {
         ...(node as any),

--- a/packages/markstream-react/src/server.ts
+++ b/packages/markstream-react/src/server.ts
@@ -5,9 +5,11 @@ export type { MarkdownCodeBlockNodeProps } from './components/MarkdownCodeBlockN
 export type { TooltipPlacement, TooltipProps } from './components/Tooltip/Tooltip'
 export {
   clearGlobalCustomComponents,
+  getCustomComponentDisplay,
   getCustomNodeComponents,
   removeCustomComponents,
   setCustomComponents,
+  withMarkstreamComponentDisplay,
 } from './customComponents'
 export { AdmonitionNode } from './server-renderer'
 export { BlockquoteNode } from './server-renderer'
@@ -57,3 +59,4 @@ export { renderNode } from './server-renderer'
 export type { NodeRendererCodeBlockProps, NodeRendererProps } from './types'
 export * from './types/component-props'
 export type { NodeComponentProps } from './types/node-component'
+export type { CustomComponentDisplayMode, MarkstreamCustomComponent } from './customComponents'

--- a/packages/markstream-react/src/utils/customHtmlTag.ts
+++ b/packages/markstream-react/src/utils/customHtmlTag.ts
@@ -1,0 +1,48 @@
+import type { ParsedNode } from 'stream-markdown-parser'
+import type { CustomComponentDisplayMode, CustomComponentMap, MarkstreamCustomComponent } from '../customComponents'
+import { getHtmlTagFromContent } from 'stream-markdown-parser'
+import { getCustomComponentDisplay } from '../customComponents'
+
+export interface ResolvedCustomHtmlTag {
+  tag: string
+  isWhitelisted: boolean
+  component: MarkstreamCustomComponent<any> | null
+  display: CustomComponentDisplayMode | undefined
+}
+
+export function resolveCustomHtmlTag(
+  node: Pick<ParsedNode, 'type'> & { tag?: string | null, content?: unknown },
+  customComponents: CustomComponentMap,
+  customHtmlTags?: readonly string[],
+): ResolvedCustomHtmlTag | null {
+  const normalizedType = String(node.type ?? '').trim().toLowerCase()
+  const normalizedTags = (customHtmlTags ?? []).map(tag => tag.toLowerCase())
+  const taggedNode = normalizedType === 'html_inline' || normalizedType === 'html_block'
+
+  if (!taggedNode && !normalizedTags.includes(normalizedType))
+    return null
+
+  const tag = taggedNode
+    ? (String(node.tag ?? '').trim().toLowerCase() || getHtmlTagFromContent(node.content))
+    : (String(node.tag ?? '').trim().toLowerCase() || normalizedType)
+  if (!tag)
+    return null
+
+  const isWhitelisted = normalizedTags.includes(tag)
+  const component = isWhitelisted ? (customComponents[tag] ?? customComponents[normalizedType] ?? null) : null
+
+  return {
+    tag,
+    isWhitelisted,
+    component,
+    display: getCustomComponentDisplay(component),
+  }
+}
+
+export function isParagraphBreakingCustomHtmlNode(
+  node: Pick<ParsedNode, 'type'> & { tag?: string | null, content?: unknown },
+  customComponents: CustomComponentMap,
+  customHtmlTags?: readonly string[],
+) {
+  return resolveCustomHtmlTag(node, customComponents, customHtmlTags)?.display === 'block'
+}

--- a/playground-react18/src/App.tsx
+++ b/playground-react18/src/App.tsx
@@ -7,6 +7,7 @@ import MermaidWorker from 'markstream-react/workers/mermaidParser.worker?worker&
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ThinkingNode } from './components/ThinkingNode'
 import { streamContent } from './markdown'
+import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from './shared/markstreamPlayground'
 import { MigrationDemoPage } from './shared/MigrationDemoPage'
 import { CUSTOM_STREAM_PRESET_ID, findMatchingStreamPreset, getStreamPreset, STREAM_PRESETS } from './shared/streamPresets'
 import { TestLab } from './shared/TestLab'
@@ -15,7 +16,6 @@ import { clampStreamControl, normalizeStreamRange, useStreamSimulator } from './
 
 setKaTeXWorker(new KatexWorker())
 setMermaidWorker(new MermaidWorker())
-const PLAYGROUND_CUSTOM_ID = 'playground-demo'
 setCustomComponents(PLAYGROUND_CUSTOM_ID, {
   thinking: ThinkingNode,
 })
@@ -744,6 +744,7 @@ export default function App() {
                 themes={themeOptions}
                 isDark={isDark}
                 customId={PLAYGROUND_CUSTOM_ID}
+                customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
                 deferNodesUntilVisible={false}
                 maxLiveNodes={2000}
                 liveNodeBuffer={200}

--- a/playground-react18/src/components/ThinkingNode.tsx
+++ b/playground-react18/src/components/ThinkingNode.tsx
@@ -1,5 +1,7 @@
 import type { NodeComponentProps } from 'markstream-react'
+import type { ReactNode } from 'react'
 import { NodeRenderer } from 'markstream-react'
+import { PLAYGROUND_CUSTOM_HTML_TAGS } from '../shared/markstreamPlayground'
 
 interface ThinkingNodeData {
   node: {
@@ -10,13 +12,29 @@ interface ThinkingNodeData {
   }
 }
 
-export function ThinkingNode(props: NodeComponentProps<ThinkingNodeData['node']>) {
-  const { node } = props
+type ThinkingNodeProps = Partial<NodeComponentProps<ThinkingNodeData['node']>> & {
+  children?: ReactNode
+}
+
+function getResolvedNode(props: ThinkingNodeProps): ThinkingNodeData['node'] {
+  if (props.node)
+    return props.node
+
+  return {
+    type: 'thinking',
+    content: '',
+    loading: false,
+  }
+}
+
+export function ThinkingNode(props: ThinkingNodeProps) {
+  const node = getResolvedNode(props)
   const dotsClass = node.loading ? 'thinking-dots visible' : 'thinking-dots hidden'
   const ctx = props.ctx
   const inheritedCustomId = props.customId ?? ctx?.customId
   const inheritedIsDark = props.isDark ?? ctx?.isDark
   const inheritedTypewriter = props.typewriter ?? ctx?.typewriter ?? true
+  const hasStructuredNode = Boolean(props.node)
 
   return (
     <div className="thinking-node p-4 my-4 bg-blue-50 dark:bg-blue-900/40 rounded-md border-l-4 border-blue-400 flex items-start gap-3">
@@ -48,25 +66,30 @@ export function ThinkingNode(props: NodeComponentProps<ThinkingNodeData['node']>
         <div className="mt-1 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
           {node.loading && <span className="sr-only" aria-live="polite">Thinking…</span>}
           <div className="content-area">
-            <NodeRenderer
-              content={String(node.content ?? '')}
-              customId={inheritedCustomId}
-              isDark={inheritedIsDark}
-              themes={ctx?.codeBlockThemes?.themes}
-              codeBlockDarkTheme={ctx?.codeBlockThemes?.darkTheme}
-              codeBlockLightTheme={ctx?.codeBlockThemes?.lightTheme}
-              codeBlockMonacoOptions={ctx?.codeBlockThemes?.monacoOptions}
-              codeBlockMinWidth={ctx?.codeBlockThemes?.minWidth}
-              codeBlockMaxWidth={ctx?.codeBlockThemes?.maxWidth}
-              codeBlockProps={ctx?.codeBlockProps}
-              codeBlockStream={ctx?.codeBlockStream}
-              renderCodeBlocksAsPre={ctx?.renderCodeBlocksAsPre}
-              typewriter={inheritedTypewriter}
-              viewportPriority={false}
-              deferNodesUntilVisible={false}
-              batchRendering={false}
-              maxLiveNodes={0}
-            />
+            {hasStructuredNode
+              ? (
+                  <NodeRenderer
+                    content={String(node.content ?? '')}
+                    customId={inheritedCustomId}
+                    customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
+                    isDark={inheritedIsDark}
+                    themes={ctx?.codeBlockThemes?.themes}
+                    codeBlockDarkTheme={ctx?.codeBlockThemes?.darkTheme}
+                    codeBlockLightTheme={ctx?.codeBlockThemes?.lightTheme}
+                    codeBlockMonacoOptions={ctx?.codeBlockThemes?.monacoOptions}
+                    codeBlockMinWidth={ctx?.codeBlockThemes?.minWidth}
+                    codeBlockMaxWidth={ctx?.codeBlockThemes?.maxWidth}
+                    codeBlockProps={ctx?.codeBlockProps}
+                    codeBlockStream={ctx?.codeBlockStream}
+                    renderCodeBlocksAsPre={ctx?.renderCodeBlocksAsPre}
+                    typewriter={inheritedTypewriter}
+                    viewportPriority={false}
+                    deferNodesUntilVisible={false}
+                    batchRendering={false}
+                    maxLiveNodes={0}
+                  />
+                )
+              : props.children}
           </div>
         </div>
       </div>

--- a/playground-react18/src/shared/MigrationDemoPage.tsx
+++ b/playground-react18/src/shared/MigrationDemoPage.tsx
@@ -5,6 +5,7 @@ import afterBasicSource from '../../../test/fixtures/react-markdown-migration-de
 import beforeAdvancedSource from '../../../test/fixtures/react-markdown-migration-demo/before-advanced.tsx?raw'
 import beforeBasicSource from '../../../test/fixtures/react-markdown-migration-demo/before-basic.tsx?raw'
 import skillOutputSource from '../../../test/fixtures/react-markdown-migration-demo/skill-output.md?raw'
+import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from './markstreamPlayground'
 
 interface MigrationDemoPageProps {
   isDark: boolean
@@ -144,6 +145,8 @@ export function MigrationDemoPage({ isDark, onGoHome, onGoTest }: MigrationDemoP
                 <NodeRenderer
                   content={skillOutputSource}
                   isDark={isDark}
+                  customId={PLAYGROUND_CUSTOM_ID}
+                  customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
                   renderCodeBlocksAsPre
                   viewportPriority={false}
                   deferNodesUntilVisible={false}

--- a/playground-react18/src/shared/TestLab.tsx
+++ b/playground-react18/src/shared/TestLab.tsx
@@ -6,6 +6,7 @@ import { NodeRenderer } from 'markstream-react'
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { TEST_LAB_FRAMEWORKS, TEST_LAB_SAMPLES } from '../../../playground-shared/testLabFixtures'
 import { buildTestPageHref, decodeMarkdownHash, resolveFrameworkTestHref, resolveTestPageViewMode } from '../../../playground-shared/testPageState'
+import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from './markstreamPlayground'
 import { CUSTOM_STREAM_PRESET_ID, findMatchingStreamPreset, getStreamPreset, STREAM_PRESETS } from './streamPresets'
 import { clampStreamControl, normalizeStreamRange, useStreamSimulator } from './useStreamSimulator'
 
@@ -533,6 +534,8 @@ export function TestLab({ frameworkLabel, onGoHome }: TestLabProps) {
                   typewriter={false}
                   codeBlockStream
                   isDark={isDark}
+                  customId={PLAYGROUND_CUSTOM_ID}
+                  customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
                   codeBlockDarkTheme="vitesse-dark"
                   codeBlockLightTheme="vitesse-light"
                 />

--- a/playground-react18/src/shared/markstreamPlayground.ts
+++ b/playground-react18/src/shared/markstreamPlayground.ts
@@ -1,0 +1,2 @@
+export const PLAYGROUND_CUSTOM_ID = 'playground-demo'
+export const PLAYGROUND_CUSTOM_HTML_TAGS = ['thinking'] as const

--- a/playground-react19/src/App.tsx
+++ b/playground-react19/src/App.tsx
@@ -5,6 +5,7 @@ import { NodeRenderer, setCustomComponents, setKaTeXWorker, setMermaidWorker } f
 import KatexWorker from 'markstream-react/workers/katexRenderer.worker?worker&inline'
 import MermaidWorker from 'markstream-react/workers/mermaidParser.worker?worker&inline'
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from '../../playground-react18/src/shared/markstreamPlayground'
 import { CUSTOM_STREAM_PRESET_ID, findMatchingStreamPreset, getStreamPreset, STREAM_PRESETS } from '../../playground-react18/src/shared/streamPresets'
 import { TestLab } from '../../playground-react18/src/shared/TestLab'
 import { useChatAutoScroll } from '../../playground-react18/src/shared/useChatAutoScroll'
@@ -14,7 +15,6 @@ import { streamContent } from './markdown'
 
 setKaTeXWorker(new KatexWorker())
 setMermaidWorker(new MermaidWorker())
-const PLAYGROUND_CUSTOM_ID = 'playground-demo'
 setCustomComponents(PLAYGROUND_CUSTOM_ID, {
   thinking: ThinkingNode,
 })
@@ -719,6 +719,7 @@ export default function App() {
                 themes={themeOptions}
                 isDark={isDark}
                 customId={PLAYGROUND_CUSTOM_ID}
+                customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
                 deferNodesUntilVisible={false}
                 maxLiveNodes={2000}
                 liveNodeBuffer={200}

--- a/playground-react19/src/components/ThinkingNode.tsx
+++ b/playground-react19/src/components/ThinkingNode.tsx
@@ -1,5 +1,7 @@
 import type { NodeComponentProps } from 'markstream-react'
+import type { ReactNode } from 'react'
 import { NodeRenderer } from 'markstream-react'
+import { PLAYGROUND_CUSTOM_HTML_TAGS } from '../../../playground-react18/src/shared/markstreamPlayground'
 
 interface ThinkingNodeData {
   node: {
@@ -10,13 +12,29 @@ interface ThinkingNodeData {
   }
 }
 
-export function ThinkingNode(props: NodeComponentProps<ThinkingNodeData['node']>) {
-  const { node } = props
+type ThinkingNodeProps = Partial<NodeComponentProps<ThinkingNodeData['node']>> & {
+  children?: ReactNode
+}
+
+function getResolvedNode(props: ThinkingNodeProps): ThinkingNodeData['node'] {
+  if (props.node)
+    return props.node
+
+  return {
+    type: 'thinking',
+    content: '',
+    loading: false,
+  }
+}
+
+export function ThinkingNode(props: ThinkingNodeProps) {
+  const node = getResolvedNode(props)
   const dotsClass = node.loading ? 'thinking-dots visible' : 'thinking-dots hidden'
   const ctx = props.ctx
   const inheritedCustomId = props.customId ?? ctx?.customId
   const inheritedIsDark = props.isDark ?? ctx?.isDark
   const inheritedTypewriter = props.typewriter ?? ctx?.typewriter ?? true
+  const hasStructuredNode = Boolean(props.node)
 
   return (
     <div className="thinking-node p-4 my-4 bg-blue-50 dark:bg-blue-900/40 rounded-md border-l-4 border-blue-400 flex items-start gap-3">
@@ -48,25 +66,30 @@ export function ThinkingNode(props: NodeComponentProps<ThinkingNodeData['node']>
         <div className="mt-1 text-sm leading-relaxed text-slate-800 dark:text-slate-100">
           {node.loading && <span className="sr-only" aria-live="polite">Thinking…</span>}
           <div className="content-area">
-            <NodeRenderer
-              content={String(node.content ?? '')}
-              customId={inheritedCustomId}
-              isDark={inheritedIsDark}
-              themes={ctx?.codeBlockThemes?.themes}
-              codeBlockDarkTheme={ctx?.codeBlockThemes?.darkTheme}
-              codeBlockLightTheme={ctx?.codeBlockThemes?.lightTheme}
-              codeBlockMonacoOptions={ctx?.codeBlockThemes?.monacoOptions}
-              codeBlockMinWidth={ctx?.codeBlockThemes?.minWidth}
-              codeBlockMaxWidth={ctx?.codeBlockThemes?.maxWidth}
-              codeBlockProps={ctx?.codeBlockProps}
-              codeBlockStream={ctx?.codeBlockStream}
-              renderCodeBlocksAsPre={ctx?.renderCodeBlocksAsPre}
-              typewriter={inheritedTypewriter}
-              viewportPriority={false}
-              deferNodesUntilVisible={false}
-              batchRendering={false}
-              maxLiveNodes={0}
-            />
+            {hasStructuredNode
+              ? (
+                  <NodeRenderer
+                    content={String(node.content ?? '')}
+                    customId={inheritedCustomId}
+                    customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}
+                    isDark={inheritedIsDark}
+                    themes={ctx?.codeBlockThemes?.themes}
+                    codeBlockDarkTheme={ctx?.codeBlockThemes?.darkTheme}
+                    codeBlockLightTheme={ctx?.codeBlockThemes?.lightTheme}
+                    codeBlockMonacoOptions={ctx?.codeBlockThemes?.monacoOptions}
+                    codeBlockMinWidth={ctx?.codeBlockThemes?.minWidth}
+                    codeBlockMaxWidth={ctx?.codeBlockThemes?.maxWidth}
+                    codeBlockProps={ctx?.codeBlockProps}
+                    codeBlockStream={ctx?.codeBlockStream}
+                    renderCodeBlocksAsPre={ctx?.renderCodeBlocksAsPre}
+                    typewriter={inheritedTypewriter}
+                    viewportPriority={false}
+                    deferNodesUntilVisible={false}
+                    batchRendering={false}
+                    maxLiveNodes={0}
+                  />
+                )
+              : props.children}
           </div>
         </div>
       </div>

--- a/test/playground-react-live-preview-config.test.ts
+++ b/test/playground-react-live-preview-config.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readSource(path: string) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+describe('playground-react live preview config', () => {
+  it('keeps the shared React playground custom scope in one place', () => {
+    const sharedSource = readSource('playground-react18/src/shared/markstreamPlayground.ts')
+
+    expect(sharedSource).toContain('PLAYGROUND_CUSTOM_ID = \'playground-demo\'')
+    expect(sharedSource).toContain('PLAYGROUND_CUSTOM_HTML_TAGS = [\'thinking\'] as const')
+  })
+
+  it('wires React 18 preview surfaces to the shared custom html config', () => {
+    const appSource = readSource('playground-react18/src/App.tsx')
+    const testLabSource = readSource('playground-react18/src/shared/TestLab.tsx')
+    const migrationSource = readSource('playground-react18/src/shared/MigrationDemoPage.tsx')
+    const thinkingSource = readSource('playground-react18/src/components/ThinkingNode.tsx')
+
+    expect(appSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from \'./shared/markstreamPlayground\'')
+    expect(appSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+
+    expect(testLabSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from \'./markstreamPlayground\'')
+    expect(testLabSource).toContain('customId={PLAYGROUND_CUSTOM_ID}')
+    expect(testLabSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+
+    expect(migrationSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from \'./markstreamPlayground\'')
+    expect(migrationSource).toContain('customId={PLAYGROUND_CUSTOM_ID}')
+    expect(migrationSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+
+    expect(thinkingSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS } from \'../shared/markstreamPlayground\'')
+    expect(thinkingSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+    expect(thinkingSource).toContain('props.children')
+  })
+
+  it('wires React 19 preview surfaces to the shared custom html config', () => {
+    const appSource = readSource('playground-react19/src/App.tsx')
+    const thinkingSource = readSource('playground-react19/src/components/ThinkingNode.tsx')
+
+    expect(appSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS, PLAYGROUND_CUSTOM_ID } from \'../../playground-react18/src/shared/markstreamPlayground\'')
+    expect(appSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+
+    expect(thinkingSource).toContain('import { PLAYGROUND_CUSTOM_HTML_TAGS } from \'../../../playground-react18/src/shared/markstreamPlayground\'')
+    expect(thinkingSource).toContain('customHtmlTags={PLAYGROUND_CUSTOM_HTML_TAGS}')
+    expect(thinkingSource).toContain('props.children')
+  })
+})

--- a/test/react-issue386-renderer-regression.test.tsx
+++ b/test/react-issue386-renderer-regression.test.tsx
@@ -7,7 +7,9 @@ import katex from 'katex'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import React, { act } from '../packages/markstream-react/node_modules/react'
 import { createRoot } from '../packages/markstream-react/node_modules/react-dom/client'
+import { renderToStaticMarkup } from '../packages/markstream-react/node_modules/react-dom/server'
 import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
+import { NodeRenderer as ServerNodeRenderer } from '../packages/markstream-react/src/server'
 import { clearKaTeXCache, clearKaTeXWorker, setKaTeXWorker } from '../packages/markstream-react/src/workers/katexWorkerClient'
 
 const REAL_WORLD_MULTILINE_INPUT = `$2.897771955 times 10^{-3}text{m·K}$^[1]^
@@ -132,8 +134,35 @@ describe('markstream-react issue #386 renderer regressions', () => {
     const view = await renderMarkdown('测试<sup>[3]</sup>。')
 
     expect(view.host.querySelector('.html-inline-node sup')?.textContent).toBe('[3]')
+    expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(view.host.querySelector('p.paragraph-node .html-inline-node sup')?.textContent).toBe('[3]')
+    expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('测试[3]。')
 
     await view.unmount()
+  })
+
+  it('keeps inline html embedded in the same paragraph on the client', async () => {
+    const view = await renderMarkdown('A<sup>[3]</sup>B')
+
+    expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(view.host.querySelector('p.paragraph-node .html-inline-node sup')?.textContent).toBe('[3]')
+    expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('A[3]B')
+
+    await view.unmount()
+  })
+
+  it('keeps inline html embedded in the same paragraph during SSR', () => {
+    const html = renderToStaticMarkup(React.createElement(ServerNodeRenderer as any, {
+      content: 'A<sup>[3]</sup>B',
+      typewriter: false,
+    }))
+
+    expect(html).toContain('<p')
+    expect(html).toContain('A')
+    expect(html).toContain('<sup>[3]</sup>')
+    expect(html).toContain('B')
+    expect(html).not.toContain('</p><span class="html-inline-node"')
+    expect(html).not.toContain('</sup></div></div></div><div class="node-slot"')
   })
 
   it('renders the real multiline issue-386 input in streaming mode without leaking raw superscript syntax', async () => {

--- a/test/react-issue386-renderer-regression.test.tsx
+++ b/test/react-issue386-renderer-regression.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable antfu/no-import-node-modules-by-path */
+import katex from 'katex'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import React, { act } from '../packages/markstream-react/node_modules/react'
+import { createRoot } from '../packages/markstream-react/node_modules/react-dom/client'
+import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
+import { clearKaTeXCache, clearKaTeXWorker, setKaTeXWorker } from '../packages/markstream-react/src/workers/katexWorkerClient'
+
+const REAL_WORLD_MULTILINE_INPUT = `$2.897771955 times 10^{-3}text{m·K}$^[1]^
+测试<sup>[3]</sup>。
+$x$^[1]^
+$x$ ^[1]^
+测试^[1]^
+$2.897771955 \\times 10^{-3}\\text{m·K}$^[1]^
+<sup>[1]</sup>
+测试<sup>[12]</sup>结束
+A<sup>[3]</sup>B
+$x$^[1]^
+测试^[1]^
+<sup>[3]</sup>
+测试<sup>[12]</sup>结束`
+
+class FakeKaTeXWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+
+  postMessage(data: { id: string, content: string, displayMode: boolean }) {
+    queueMicrotask(() => {
+      try {
+        const html = katex.renderToString(data.content, {
+          throwOnError: false,
+          displayMode: data.displayMode,
+          output: 'html',
+          strict: 'ignore',
+        })
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            html,
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+      catch (error: any) {
+        this.onmessage?.({
+          data: {
+            id: data.id,
+            error: error?.message || String(error),
+            content: data.content,
+            displayMode: data.displayMode,
+          },
+        } as MessageEvent)
+      }
+    })
+  }
+
+  terminate() {}
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderMarkdown(content: string, extraProps: Record<string, unknown> = {}) {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+
+  await act(async () => {
+    root.render(React.createElement(NodeRenderer as any, {
+      content,
+      viewportPriority: false,
+      deferNodesUntilVisible: false,
+      maxLiveNodes: 0,
+      ...extraProps,
+    }))
+  })
+  await flushReact()
+
+  return {
+    host,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+    },
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  setKaTeXWorker(new FakeKaTeXWorker() as unknown as Worker)
+})
+
+afterEach(() => {
+  clearKaTeXWorker()
+  clearKaTeXCache()
+  document.body.innerHTML = ''
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = false
+})
+
+describe('markstream-react issue #386 renderer regressions', () => {
+  it('renders bracketed superscript syntax from markdown content', async () => {
+    const view = await renderMarkdown('测试^[1]^')
+
+    expect(view.host.querySelector('sup.superscript-node')?.textContent).toBe('[1]')
+    expect(view.host.textContent).not.toContain('^[1]^')
+
+    await view.unmount()
+  })
+
+  it('renders superscript syntax immediately after inline math', async () => {
+    const view = await renderMarkdown('$x$^[1]^')
+
+    expect(view.host.querySelector('.katex')).toBeTruthy()
+    expect(view.host.querySelector('sup.superscript-node')?.textContent).toBe('[1]')
+    expect(view.host.textContent).not.toContain('^[1]^')
+
+    await view.unmount()
+  })
+
+  it('preserves brackets inside standard inline html tags', async () => {
+    const view = await renderMarkdown('测试<sup>[3]</sup>。')
+
+    expect(view.host.querySelector('.html-inline-node sup')?.textContent).toBe('[3]')
+
+    await view.unmount()
+  })
+
+  it('renders the real multiline issue-386 input in streaming mode without leaking raw superscript syntax', async () => {
+    const view = await renderMarkdown(REAL_WORLD_MULTILINE_INPUT, { final: false })
+
+    const superscripts = Array.from(view.host.querySelectorAll('sup.superscript-node')).map(node => node.textContent)
+    const inlineHtmlSup = Array.from(view.host.querySelectorAll('.html-inline-node sup')).map(node => node.textContent)
+
+    expect(view.host.querySelector('.katex')).toBeTruthy()
+    expect(superscripts).toEqual(['[1]', '[1]', '[1]', '[1]', '[1]', '[1]', '[1]'])
+    expect(inlineHtmlSup).toEqual(['[3]', '[1]', '[12]', '[3]', '[3]', '[12]'])
+    expect(view.host.textContent).not.toContain('^[1]^')
+
+    await view.unmount()
+  })
+})

--- a/test/react-issue386-renderer-regression.test.tsx
+++ b/test/react-issue386-renderer-regression.test.tsx
@@ -9,6 +9,7 @@ import React, { act } from '../packages/markstream-react/node_modules/react'
 import { createRoot } from '../packages/markstream-react/node_modules/react-dom/client'
 import { renderToStaticMarkup } from '../packages/markstream-react/node_modules/react-dom/server'
 import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
+import { removeCustomComponents, setCustomComponents, withMarkstreamComponentDisplay } from '../packages/markstream-react/src/customComponents'
 import { NodeRenderer as ServerNodeRenderer } from '../packages/markstream-react/src/server'
 import { clearKaTeXCache, clearKaTeXWorker, setKaTeXWorker } from '../packages/markstream-react/src/workers/katexWorkerClient'
 
@@ -77,19 +78,25 @@ async function renderMarkdown(content: string, extraProps: Record<string, unknow
   document.body.appendChild(host)
   const root = createRoot(host)
 
-  await act(async () => {
-    root.render(React.createElement(NodeRenderer as any, {
-      content,
-      viewportPriority: false,
-      deferNodesUntilVisible: false,
-      maxLiveNodes: 0,
-      ...extraProps,
-    }))
-  })
-  await flushReact()
+  const rerender = async (nextContent: string, nextProps: Record<string, unknown> = {}) => {
+    await act(async () => {
+      root.render(React.createElement(NodeRenderer as any, {
+        content: nextContent,
+        viewportPriority: false,
+        deferNodesUntilVisible: false,
+        maxLiveNodes: 0,
+        ...extraProps,
+        ...nextProps,
+      }))
+    })
+    await flushReact()
+  }
+
+  await rerender(content)
 
   return {
     host,
+    rerender,
     unmount: async () => {
       await act(async () => {
         root.unmount()
@@ -122,6 +129,16 @@ describe('markstream-react issue #386 renderer regressions', () => {
 
   it('renders superscript syntax immediately after inline math', async () => {
     const view = await renderMarkdown('$x$^[1]^')
+
+    expect(view.host.querySelector('.katex')).toBeTruthy()
+    expect(view.host.querySelector('sup.superscript-node')?.textContent).toBe('[1]')
+    expect(view.host.textContent).not.toContain('^[1]^')
+
+    await view.unmount()
+  })
+
+  it('renders superscript syntax after inline math even with separating whitespace', async () => {
+    const view = await renderMarkdown('$x$ ^[1]^')
 
     expect(view.host.querySelector('.katex')).toBeTruthy()
     expect(view.host.querySelector('sup.superscript-node')?.textContent).toBe('[1]')
@@ -163,6 +180,129 @@ describe('markstream-react issue #386 renderer regressions', () => {
     expect(html).toContain('B')
     expect(html).not.toContain('</p><span class="html-inline-node"')
     expect(html).not.toContain('</sup></div></div></div><div class="node-slot"')
+  })
+
+  it('recovers incomplete inline html during streaming updates without breaking the paragraph', async () => {
+    const view = await renderMarkdown('A<sup>[3]', { final: false })
+
+    expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(view.host.querySelector('p.paragraph-node .html-inline-node sup')?.textContent).toBe('[3]')
+    expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('A[3]')
+    expect(view.host.textContent).not.toContain('<sup>[3]')
+
+    await view.rerender('A<sup>[3]</sup>B', { final: false })
+
+    expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+    expect(view.host.querySelector('p.paragraph-node .html-inline-node sup')?.textContent).toBe('[3]')
+    expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('A[3]B')
+    expect(view.host.textContent).not.toContain('<sup>[3]')
+
+    await view.unmount()
+  })
+
+  it('keeps whitelisted custom inline tags embedded in the same paragraph', async () => {
+    const scopeId = 'react-inline-ref-regression'
+    const InlineRef: React.FC<{ node: { content?: string } }> = ({ node }) => (
+      <sup className="inline-ref-node">{node.content || ''}</sup>
+    )
+    setCustomComponents(scopeId, { 'inline-ref': InlineRef })
+
+    try {
+      const view = await renderMarkdown('A<inline-ref>[7]</inline-ref>B', {
+        customId: scopeId,
+        customHtmlTags: ['inline-ref'],
+        final: true,
+      })
+
+      expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(1)
+      expect(view.host.querySelector('p.paragraph-node .inline-ref-node')?.textContent).toBe('[7]')
+      expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('A[7]B')
+
+      await view.unmount()
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('keeps whitelisted custom inline tags embedded in the same paragraph during SSR', () => {
+    const scopeId = 'react-inline-ref-ssr-regression'
+    const InlineRef: React.FC<{ node: { content?: string } }> = ({ node }) => (
+      <sup className="inline-ref-node">{node.content || ''}</sup>
+    )
+    setCustomComponents(scopeId, { 'inline-ref': InlineRef })
+
+    try {
+      const html = renderToStaticMarkup(React.createElement(ServerNodeRenderer as any, {
+        content: 'A<inline-ref>[7]</inline-ref>B',
+        customId: scopeId,
+        customHtmlTags: ['inline-ref'],
+        typewriter: false,
+      }))
+
+      expect(html).toContain('<p')
+      expect(html).toContain('A')
+      expect(html).toContain('<sup class="inline-ref-node">[7]</sup>')
+      expect(html).toContain('B')
+      expect(html).not.toContain('</p><sup class="inline-ref-node">[7]</sup>')
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('lets block-marked custom html tags break out of paragraph wrappers on the client', async () => {
+    const scopeId = 'react-blockish-inline-tag-client'
+    const BlockRef = withMarkstreamComponentDisplay((({ node }: { node: { content?: string } }) => (
+      <div className="block-ref-node">{node.content || ''}</div>
+    )), 'block')
+
+    setCustomComponents(scopeId, { 'inline-ref': BlockRef })
+
+    try {
+      const view = await renderMarkdown('A<inline-ref>[7]</inline-ref>B', {
+        customId: scopeId,
+        customHtmlTags: ['inline-ref'],
+        final: true,
+      })
+
+      expect(view.host.querySelectorAll('p.paragraph-node')).toHaveLength(2)
+      expect(view.host.querySelector('p.paragraph-node')?.textContent).toBe('A')
+      expect(view.host.querySelector('.block-ref-node')?.textContent).toBe('[7]')
+      expect(Array.from(view.host.querySelectorAll('p.paragraph-node')).at(1)?.textContent).toBe('B')
+      expect(view.host.innerHTML).not.toContain('<p dir="auto" class="paragraph-node">A<div')
+
+      await view.unmount()
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
+  })
+
+  it('lets block-marked custom html tags break out of paragraph wrappers during SSR', () => {
+    const scopeId = 'react-blockish-inline-tag-ssr'
+    const BlockRef = withMarkstreamComponentDisplay((({ node }: { node: { content?: string } }) => (
+      <div className="block-ref-node">{node.content || ''}</div>
+    )), 'block')
+
+    setCustomComponents(scopeId, { 'inline-ref': BlockRef })
+
+    try {
+      const html = renderToStaticMarkup(React.createElement(ServerNodeRenderer as any, {
+        content: 'A<inline-ref>[7]</inline-ref>B',
+        customId: scopeId,
+        customHtmlTags: ['inline-ref'],
+        typewriter: false,
+      }))
+
+      expect(html).toContain('<div class="block-ref-node">[7]</div>')
+      expect(html).not.toContain('<p dir="auto" class="paragraph-node">A<div class="block-ref-node">[7]</div>B</p>')
+      expect(html).toContain('<p dir="auto" class="paragraph-node"><span class="text-node whitespace-pre-wrap break-words">A</span></p>')
+      expect(html).toContain('<p dir="auto" class="paragraph-node"><span class="text-node whitespace-pre-wrap break-words">B</span></p>')
+    }
+    finally {
+      removeCustomComponents(scopeId)
+    }
   })
 
   it('renders the real multiline issue-386 input in streaming mode without leaking raw superscript syntax', async () => {


### PR DESCRIPTION
## Summary

Fix the React live preview so inline HTML references like `<sup>[3]</sup>` and markdown superscripts like `^[1]^` stay inside the same paragraph instead of being split into the wrong structure.
This also adds an explicit React escape hatch for custom HTML tags that intentionally render block DOM, so we avoid invalid `<p>` nesting without regressing the inline fix.

## Changes

- [x] Keep `html_inline` content inside React paragraph rendering so inline `<sup>` references render correctly in live preview and SSR
- [x] Add a React custom-component display hint (`markstreamDisplay` / `withMarkstreamComponentDisplay`) so block-like custom HTML tags can break out of paragraph wrappers safely
- [x] Align React 18 / React 19 playground live preview config so trusted custom HTML tags are wired consistently
- [x] Add regression coverage for client, SSR, streaming, inline math + superscript spacing, and block-marked custom tag behavior

## Screenshots / Demo (if UI/behavior changes)

- [x] Added GIF/screenshot
after
<img width="1181" height="540" alt="image" src="https://github.com/user-attachments/assets/5f27f4af-9cb4-4985-ad39-22fb045706e3" />

- [x] Shareable repro link from https://markstream-vue.simonhe.me/test (recommended)

Repro / expected rendering:
before
https://markstream-react.pages.dev/test?view=preview#data=z:UzHSs7A0Nzc3tDQ1VSjJzE0tVjA0iKvWNa4tSa0oqc49tN27ViUu2jA2juvZ1u4X66faFJcW2EUbx9rogxiPG5q4VCqgCoAMBWSlUFFkG2JQrIjBsANiuiHUdBQrDY2gos93T342dz6XI6pLnBDuQLYdVRE-AwE
<img width="1401" height="528" alt="image" src="https://github.com/user-attachments/assets/2916a156-1ca2-4734-a327-03b2106c45f3" />


## Checklist

- [x] Lint: `pnpm lint`
- [x] Typecheck: `pnpm typecheck`
- [x] Tests: `pnpm test` (or `pnpm test:update` if snapshots changed)
- [x] Build: `pnpm build` (library + CSS)

Lint skipped for this round per request.
