### PR TITLE
fix: sanitize raw html fallback rendering

### DIFF
--- a/packages/markdown-parser/src/htmlRenderUtils.ts
+++ b/packages/markdown-parser/src/htmlRenderUtils.ts
@@ -1,4 +1,5 @@
 import {
+  BLOCKED_HTML_TAGS,
   DANGEROUS_HTML_ATTRS,
   EXTENDED_STANDARD_HTML_TAGS,
   isUnsafeHtmlUrl,
@@ -17,6 +18,63 @@ const CUSTOM_TAG_REGEX = /<([a-z][a-z0-9-]*)\b[^>]*>/gi
 
 function hasOwn(obj: Record<string, unknown>, key: string) {
   return Object.prototype.hasOwnProperty.call(obj, key)
+}
+
+function getString(value: unknown): string {
+  return typeof value === 'string'
+    ? value
+    : value == null
+      ? ''
+      : String(value)
+}
+
+function isSafeAttrName(value: string): boolean {
+  return /^[^\s"'<>`=]+$/.test(value) && !/^on/i.test(value)
+}
+
+function escapeHtml(value: unknown): string {
+  return getString(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function escapeAttr(value: unknown): string {
+  return escapeHtml(value).replace(/`/g, '&#96;')
+}
+
+function normalizeTagName(tagName: string | undefined): string {
+  return String(tagName ?? '').trim().toLowerCase()
+}
+
+function serializeAttrs(attrs: Record<string, string>): string {
+  const pairs = Object.entries(attrs)
+  if (pairs.length === 0)
+    return ''
+
+  return pairs
+    .map(([name, value]) => value === '' ? ` ${name}` : ` ${name}="${escapeAttr(value)}"`)
+    .join('')
+}
+
+function sanitizeHtmlContentAttrs(attrs: Record<string, string>) {
+  const clean: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(attrs)) {
+    const safeName = key.trim()
+    const lowerKey = safeName.toLowerCase()
+    if (!safeName || !isSafeAttrName(safeName))
+      continue
+    if (DANGEROUS_HTML_ATTRS.has(lowerKey))
+      continue
+    if (URL_HTML_ATTRS.has(lowerKey) && value && isUnsafeHtmlUrl(value))
+      continue
+    clean[safeName] = value
+  }
+
+  return clean
 }
 
 export function isCustomHtmlComponentTag(
@@ -187,6 +245,104 @@ export function tokenizeHtml(html: string): HtmlToken[] {
   return tokens
 }
 
+function tokenizeHtmlPreservingText(html: string): HtmlToken[] {
+  const tokens: HtmlToken[] = []
+  let pos = 0
+
+  while (pos < html.length) {
+    if (html.startsWith('<!--', pos)) {
+      const commentEnd = html.indexOf('-->', pos)
+      if (commentEnd !== -1) {
+        pos = commentEnd + 3
+        continue
+      }
+      break
+    }
+
+    const tagStart = html.indexOf('<', pos)
+    if (tagStart === -1) {
+      if (pos < html.length)
+        tokens.push({ type: 'text', content: html.slice(pos) })
+      break
+    }
+
+    if (tagStart > pos)
+      tokens.push({ type: 'text', content: html.slice(pos, tagStart) })
+
+    if (html.startsWith('![CDATA[', tagStart + 1)) {
+      const cdataEnd = html.indexOf(']]>', tagStart)
+      if (cdataEnd !== -1) {
+        tokens.push({ type: 'text', content: html.slice(tagStart, cdataEnd + 3) })
+        pos = cdataEnd + 3
+        continue
+      }
+      break
+    }
+
+    if (html.startsWith('!', tagStart + 1)) {
+      const specialEnd = html.indexOf('>', tagStart)
+      if (specialEnd !== -1) {
+        pos = specialEnd + 1
+        continue
+      }
+      break
+    }
+
+    const tagEnd = html.indexOf('>', tagStart)
+    if (tagEnd === -1)
+      break
+
+    const tagContent = html.slice(tagStart + 1, tagEnd).trim()
+    if (!tagContent) {
+      pos = tagEnd + 1
+      continue
+    }
+
+    const isClosingTag = tagContent.startsWith('/')
+    const isSelfClosing = tagContent.endsWith('/')
+
+    if (isClosingTag) {
+      const tagName = tagContent.slice(1).trim()
+      tokens.push({ type: 'tag_close', tagName })
+      pos = tagEnd + 1
+      continue
+    }
+
+    const spaceIndex = tagContent.indexOf(' ')
+    let tagName = ''
+    let attrsStr = ''
+    if (spaceIndex === -1) {
+      tagName = isSelfClosing ? tagContent.slice(0, -1).trim() : tagContent.trim()
+    }
+    else {
+      tagName = tagContent.slice(0, spaceIndex).trim()
+      attrsStr = tagContent.slice(spaceIndex + 1)
+    }
+
+    const attrs: Record<string, string> = {}
+    if (attrsStr) {
+      const attrRegex = /([^\s=]+)(?:=(?:"([^"]*)"|'([^']*)'|(\S*)))?/g
+      let attrMatch: RegExpExecArray | null
+      while ((attrMatch = attrRegex.exec(attrsStr)) !== null) {
+        const name = attrMatch[1]
+        const value = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4] ?? ''
+        if (name && !name.endsWith('/'))
+          attrs[name] = value
+      }
+    }
+
+    tokens.push({
+      type: isSelfClosing || VOID_HTML_TAGS.has(tagName.toLowerCase()) ? 'self_closing' : 'tag_open',
+      tagName,
+      attrs,
+    })
+
+    pos = tagEnd + 1
+  }
+
+  return tokens
+}
+
 export function hasCustomHtmlComponents(
   content: string,
   customComponents: Record<string, unknown>,
@@ -202,4 +358,71 @@ export function hasCustomHtmlComponents(
       return true
   }
   return false
+}
+
+export function sanitizeHtmlContent(content: string): string {
+  if (!content)
+    return ''
+
+  const tokens = tokenizeHtmlPreservingText(content)
+  const stack: string[] = []
+  const output: string[] = []
+  let blockedDepth = 0
+
+  for (const token of tokens) {
+    if (token.type === 'text') {
+      if (blockedDepth === 0)
+        output.push(escapeHtml(token.content ?? ''))
+      continue
+    }
+
+    const tagName = normalizeTagName(token.tagName)
+    if (!tagName)
+      continue
+
+    if (BLOCKED_HTML_TAGS.has(tagName)) {
+      if (token.type === 'tag_open')
+        blockedDepth += 1
+      else if (token.type === 'tag_close' && blockedDepth > 0)
+        blockedDepth -= 1
+      continue
+    }
+
+    if (blockedDepth > 0)
+      continue
+
+    if (token.type === 'self_closing') {
+      output.push(`<${tagName}${serializeAttrs(sanitizeHtmlContentAttrs(token.attrs ?? {}))}>`)
+      continue
+    }
+
+    if (token.type === 'tag_open') {
+      output.push(`<${tagName}${serializeAttrs(sanitizeHtmlContentAttrs(token.attrs ?? {}))}>`)
+      if (!VOID_HTML_TAGS.has(tagName))
+        stack.push(tagName)
+      continue
+    }
+
+    const matchedIndex = stack.lastIndexOf(tagName)
+    if (matchedIndex === -1)
+      continue
+
+    while (stack.length > matchedIndex + 1) {
+      const danglingTag = stack.pop()
+      if (danglingTag)
+        output.push(`</${danglingTag}>`)
+    }
+
+    const closingTag = stack.pop()
+    if (closingTag)
+      output.push(`</${closingTag}>`)
+  }
+
+  while (stack.length > 0) {
+    const danglingTag = stack.pop()
+    if (danglingTag)
+      output.push(`</${danglingTag}>`)
+  }
+
+  return output.join('')
 }

--- a/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
+++ b/packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode.tsx
@@ -1,6 +1,6 @@
 import type { NodeComponentProps } from '../../types/node-component'
-import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlTokenAttrs } from 'stream-markdown-parser'
 import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlContent, sanitizeHtmlTokenAttrs } from 'stream-markdown-parser'
 import { useViewportPriority } from '../../context/viewportPriority'
 import { getCustomComponentsRevision, getCustomNodeComponents, subscribeCustomComponents } from '../../customComponents'
 import { renderNodeChildren, tokenAttrsToProps } from '../../renderers/renderChildren'
@@ -107,6 +107,7 @@ export function HtmlBlockNode(props: NodeComponentProps<{
       return null
     return parseHtmlToReactNodes(node.content, effectiveCustomComponents)
   }, [effectiveCustomComponents, node.content, useDynamic])
+  const safeHtmlContent = useMemo(() => sanitizeHtmlContent(renderContent ?? ''), [renderContent])
   const structuredContent = useMemo(() => {
     if (!isStructured || !props.ctx || !props.renderNode)
       return null
@@ -150,7 +151,7 @@ export function HtmlBlockNode(props: NodeComponentProps<{
                   <>{reactNodes}</>
                 )
               : (
-                  <div dangerouslySetInnerHTML={{ __html: renderContent ?? '' }} />
+                  <div dangerouslySetInnerHTML={{ __html: safeHtmlContent }} />
                 )
           )
         : placeholderNode}

--- a/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
+++ b/packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode.tsx
@@ -2,7 +2,7 @@ import type { ComponentType } from 'react'
 import type { NodeComponentProps } from '../../types/node-component'
 import type { HtmlToken } from '../../utils/htmlToReact'
 import React, { useEffect, useRef, useState } from 'react'
-import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps } from 'stream-markdown-parser'
+import { BLOCKED_HTML_TAGS as BLOCKED_TAGS, convertHtmlAttrsToProps, sanitizeHtmlContent } from 'stream-markdown-parser'
 import { getCustomNodeComponents } from '../../customComponents'
 import {
   hasCustomHtmlComponents,
@@ -171,6 +171,7 @@ export function HtmlInlineNode(props: NodeComponentProps<{
 
   // Get custom components from global registry
   const customComponents = getCustomNodeComponents(customId)
+  const safeHtmlContent = React.useMemo(() => sanitizeHtmlContent(node.content ?? ''), [node.content])
 
   // Computed property to determine render mode and content
   const renderMode = React.useMemo(() => {
@@ -198,9 +199,9 @@ export function HtmlInlineNode(props: NodeComponentProps<{
     const host = containerRef.current
     host.innerHTML = ''
     const template = document.createElement('template')
-    template.innerHTML = node.content ?? ''
+    template.innerHTML = safeHtmlContent
     host.appendChild(template.content.cloneNode(true))
-  }, [node.content, renderMode.mode, isClient])
+  }, [renderMode.mode, isClient, safeHtmlContent])
 
   // Loading state handling
   if (node.loading && !node.autoClosed) {

--- a/packages/markstream-vue2/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/packages/markstream-vue2/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
+import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { computed, defineComponent, onBeforeUnmount, ref, watch } from 'vue-demi'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
@@ -70,7 +70,7 @@ const renderMode = computed(() => {
 
   // Check if content contains custom components
   if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content }
+    return { mode: 'html', content: sanitizeHtmlContent(content) }
 
   return { mode: 'dynamic', content }
 })
@@ -127,17 +127,19 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
+  <!-- eslint-disable vue/no-v-text-v-html-on-component -->
   <component
-    v-if="renderMode.mode === 'structured' && shouldRender"
     :is="structuredTag"
+    v-if="renderMode.mode === 'structured' && shouldRender"
     ref="htmlRef"
     class="html-block-node"
     v-bind="boundAttrs"
     v-html="structuredHtml"
   />
+  <!-- eslint-enable vue/no-v-text-v-html-on-component -->
   <component
-    v-else-if="renderMode.mode === 'structured'"
     :is="structuredTag"
+    v-else-if="renderMode.mode === 'structured'"
     ref="htmlRef"
     class="html-block-node"
     v-bind="boundAttrs"
@@ -159,7 +161,7 @@ onBeforeUnmount(() => {
       <!-- Use dynamic rendering for custom components -->
       <DynamicRenderer v-if="renderMode.mode === 'dynamic'" :content="renderMode.content" :custom-components="customComponents" />
       <!-- Fallback to v-html for standard HTML -->
-      <div v-else v-bind="boundAttrs" v-html="renderContent" />
+      <div v-else v-bind="boundAttrs" v-html="renderMode.content" />
     </template>
     <div v-else class="html-block-node__placeholder">
       <slot name="placeholder" :node="node">

--- a/packages/markstream-vue2/src/components/HtmlInlineNode/HtmlInlineNode.vue
+++ b/packages/markstream-vue2/src/components/HtmlInlineNode/HtmlInlineNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { sanitizeHtmlContent } from 'stream-markdown-parser'
 import { computed, defineComponent } from 'vue-demi'
 import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
 import { getCustomNodeComponents } from '../../utils/nodeComponents'
@@ -49,7 +50,7 @@ const renderMode = computed(() => {
 
   // Check if content contains custom components
   if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content }
+    return { mode: 'html', content: sanitizeHtmlContent(content) }
 
   return { mode: 'dynamic', content }
 })

--- a/src/components/HtmlBlockNode/HtmlBlockNode.vue
+++ b/src/components/HtmlBlockNode/HtmlBlockNode.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
+import { NON_STRUCTURING_HTML_TAGS, sanitizeHtmlContent, sanitizeHtmlTokenAttrs, tokenAttrsToRecord } from 'stream-markdown-parser'
 import { computed, defineAsyncComponent, defineComponent, onBeforeUnmount, ref, watch } from 'vue'
 import { useViewportPriority } from '../../composables/viewportPriority'
 import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
@@ -84,12 +84,12 @@ const renderMode = computed(() => {
 
   // Check if content contains custom components
   if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content }
+    return { mode: 'html', content: sanitizeHtmlContent(content) }
 
   // Parse and build VNode tree
   const nodes = parseHtmlToVNodes(content, customComponents.value)
   if (nodes === null)
-    return { mode: 'html', content } // Fallback to v-html if parsing fails
+    return { mode: 'html', content: sanitizeHtmlContent(content) } // Fallback to sanitized HTML if parsing fails
 
   return { mode: 'dynamic', nodes }
 })
@@ -161,7 +161,7 @@ onBeforeUnmount(() => {
       <DynamicRenderer v-else-if="renderMode.mode === 'dynamic'" :nodes="renderMode.nodes" />
       <pre v-else-if="renderMode.mode === 'text'" class="html-block-node__raw">{{ renderMode.content }}</pre>
       <!-- Fallback to v-html for standard HTML -->
-      <div v-else v-bind="boundAttrs" v-html="renderContent" />
+      <div v-else v-bind="boundAttrs" v-html="renderMode.content" />
     </template>
     <div v-else class="html-block-node__placeholder">
       <slot name="placeholder" :node="node">

--- a/src/components/HtmlInlineNode/HtmlInlineNode.vue
+++ b/src/components/HtmlInlineNode/HtmlInlineNode.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { sanitizeHtmlContent } from 'stream-markdown-parser'
 import { computed, defineComponent } from 'vue'
 import { hasCustomComponents, parseHtmlToVNodes } from '../../utils/htmlRenderer'
 import { customComponentsRevision, getCustomNodeComponents } from '../../utils/nodeComponents'
@@ -55,12 +56,12 @@ const renderMode = computed(() => {
 
   // Check if content contains custom components
   if (!hasCustomComponents(content, customComponents.value))
-    return { mode: 'html', content }
+    return { mode: 'html', content: sanitizeHtmlContent(content) }
 
   // Parse and build VNode tree
   const nodes = parseHtmlToVNodes(content, customComponents.value)
   if (nodes === null)
-    return { mode: 'html', content } // Fallback to DOM rendering if parsing fails
+    return { mode: 'html', content: sanitizeHtmlContent(content) } // Fallback to sanitized DOM rendering if parsing fails
 
   return { mode: 'dynamic', nodes }
 })

--- a/src/components/__tests__/htmlNodes.integration.test.ts
+++ b/src/components/__tests__/htmlNodes.integration.test.ts
@@ -5,11 +5,11 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
+import { flushAll } from '../../../test/setup/flush-all'
 import HtmlBlockNode from '../../components/HtmlBlockNode/HtmlBlockNode.vue'
 import HtmlInlineNode from '../../components/HtmlInlineNode/HtmlInlineNode.vue'
 import MarkdownRender from '../../components/NodeRenderer'
 import { setCustomComponents } from '../../utils/nodeComponents'
-import { flushAll } from '../../../test/setup/flush-all'
 
 // Mock custom components
 const TestComponent = defineComponent({
@@ -132,6 +132,30 @@ describe('htmlBlockNode - Custom Components Integration', () => {
 
     expect(wrapper.find('.standard').exists()).toBe(true)
     expect(wrapper.html()).toContain('Pure HTML')
+  })
+
+  it('should sanitize raw HTML fallback content in blocks', async () => {
+    const wrapper = mount(HtmlBlockNode, {
+      props: {
+        node: {
+          content: '<div><img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a><script>alert(1)</script></div>',
+          loading: false,
+        },
+        customId: testId,
+      },
+    })
+
+    await nextTick()
+    const img = wrapper.find('img')
+    const link = wrapper.find('a')
+
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('onerror')).toBeUndefined()
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBeUndefined()
+    expect(link.attributes('title')).toBe('ok')
+    expect(wrapper.html()).not.toContain('<script')
+    expect(wrapper.html()).not.toContain('alert(1)')
   })
 
   it('should pass props correctly to custom components', () => {
@@ -264,6 +288,30 @@ describe('htmlInlineNode - Custom Components Integration', () => {
     expect(wrapper.find('.html-inline-node').exists()).toBe(true)
     expect(wrapper.find('.standard').exists()).toBe(true)
     expect(wrapper.find('.standard').text()).toBe('Pure HTML')
+  })
+
+  it('should sanitize raw HTML fallback content inline', async () => {
+    const wrapper = mount(HtmlInlineNode, {
+      props: {
+        node: {
+          type: 'html_inline',
+          content: 'Before <img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a> After',
+          loading: false,
+        },
+        customId: testId,
+      },
+    })
+
+    await nextTick()
+    const img = wrapper.find('img')
+    const link = wrapper.find('a')
+
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('onerror')).toBeUndefined()
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBeUndefined()
+    expect(link.attributes('title')).toBe('ok')
+    expect(wrapper.html()).not.toContain('alert(1)')
   })
 
   it('should handle mixed inline content', () => {

--- a/test/html-sanitize-content.test.ts
+++ b/test/html-sanitize-content.test.ts
@@ -1,0 +1,21 @@
+import { sanitizeHtmlContent } from 'stream-markdown-parser'
+import { describe, expect, it } from 'vitest'
+
+describe('sanitizeHtmlContent', () => {
+  it('removes dangerous attrs, unsafe urls, and blocked tags', () => {
+    const html = sanitizeHtmlContent('<div onclick="evil()">Hello <img src="x" onerror="evil()"><a href="javascript:alert(1)" title="ok">Link</a><script>alert(1)</script></div>')
+
+    expect(html).toContain('<div>Hello <img src="x"><a title="ok">Link</a></div>')
+    expect(html).not.toContain('onclick')
+    expect(html).not.toContain('onerror')
+    expect(html).not.toContain('javascript:')
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('alert(1)')
+  })
+
+  it('preserves whitespace around safe inline html', () => {
+    const html = sanitizeHtmlContent('Hello <span data-safe="1">world</span> !')
+
+    expect(html).toBe('Hello <span data-safe="1">world</span> !')
+  })
+})

--- a/test/react-non-whitelisted-html-tag.test.tsx
+++ b/test/react-non-whitelisted-html-tag.test.tsx
@@ -11,6 +11,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import React, { act, StrictMode } from '../packages/markstream-react/node_modules/react'
 import { createRoot } from '../packages/markstream-react/node_modules/react-dom/client'
+import { HtmlBlockNode } from '../packages/markstream-react/src/components/HtmlBlockNode/HtmlBlockNode'
+import { HtmlInlineNode } from '../packages/markstream-react/src/components/HtmlInlineNode/HtmlInlineNode'
 import { NodeRenderer } from '../packages/markstream-react/src/components/NodeRenderer'
 import { removeCustomComponents, setCustomComponents } from '../packages/markstream-react/src/customComponents'
 
@@ -101,6 +103,51 @@ describe('react: non-whitelisted custom HTML tags', () => {
     expect(html).toContain('<div')
     expect(html).toContain('</div>')
     expect(html).toContain('Content')
+
+    root.unmount()
+  })
+
+  it('sanitizes raw html fallback content for client html nodes', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    const blockNode = React.createElement(HtmlBlockNode as any, {
+      node: {
+        type: 'html_block',
+        content: '<div><img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a><script>alert(1)</script></div>',
+        loading: false,
+      },
+      customId: 'react-safe-html-block',
+    })
+    const inlineNode = React.createElement(HtmlInlineNode as any, {
+      node: {
+        type: 'html_inline',
+        content: 'Before <img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a> After',
+        loading: false,
+      },
+      customId: 'react-safe-html-inline',
+    })
+
+    await act(async () => {
+      root.render(
+        React.createElement(StrictMode, null, React.createElement(React.Fragment, null, blockNode, inlineNode)),
+      )
+    })
+    await flushReact()
+
+    const imgs = Array.from(host.querySelectorAll('img'))
+    const links = Array.from(host.querySelectorAll('a'))
+
+    expect(imgs.length).toBeGreaterThan(0)
+    imgs.forEach(img => expect(img.getAttribute('onerror')).toBeNull())
+    expect(links.length).toBeGreaterThan(0)
+    links.forEach((link) => {
+      expect(link.getAttribute('href')).toBeNull()
+      expect(link.getAttribute('title')).toBe('ok')
+    })
+    expect(host.innerHTML).not.toContain('<script')
+    expect(host.innerHTML).not.toContain('javascript:')
+    expect(host.innerHTML).not.toContain('alert(1)')
 
     root.unmount()
   })

--- a/test/vue2-html-nodes.test.ts
+++ b/test/vue2-html-nodes.test.ts
@@ -137,6 +137,30 @@ describe('vue 2 - HtmlBlockNode Custom Components Integration', () => {
     expect(wrapper.html()).toContain('Pure HTML')
   })
 
+  it('should sanitize raw HTML fallback content in blocks', async () => {
+    const wrapper = mount(HtmlBlockNode, {
+      props: {
+        node: {
+          content: '<div><img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a><script>alert(1)</script></div>',
+          loading: false,
+        },
+        customId: testId,
+      },
+    })
+
+    await flushAll()
+    const img = wrapper.find('img')
+    const link = wrapper.find('a')
+
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('onerror')).toBeUndefined()
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBeUndefined()
+    expect(link.attributes('title')).toBe('ok')
+    expect(wrapper.html()).not.toContain('<script')
+    expect(wrapper.html()).not.toContain('alert(1)')
+  })
+
   it('should pass props correctly to custom components', () => {
     const wrapper = mount(HtmlBlockNode, {
       props: {
@@ -332,6 +356,30 @@ describe('vue 2 - HtmlInlineNode Custom Components Integration', () => {
 
     // HtmlInlineNode uses DOM manipulation, check that the container exists
     expect(wrapper.find('.html-inline-node').exists()).toBe(true)
+  })
+
+  it('should sanitize raw HTML fallback content inline', async () => {
+    const wrapper = mount(HtmlInlineNode, {
+      props: {
+        node: {
+          type: 'html_inline',
+          content: 'Before <img src="x" onerror="alert(1)"><a href="javascript:alert(1)" title="ok">Link</a> After',
+          loading: false,
+        },
+        customId: testId,
+      },
+    })
+
+    await flushAll()
+    const img = wrapper.find('img')
+    const link = wrapper.find('a')
+
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('onerror')).toBeUndefined()
+    expect(link.exists()).toBe(true)
+    expect(link.attributes('href')).toBeUndefined()
+    expect(link.attributes('title')).toBe('ok')
+    expect(wrapper.html()).not.toContain('alert(1)')
   })
 
   it('should handle mixed inline content', () => {


### PR DESCRIPTION
Closes #389

## Summary

This change fixes an XSS vulnerability in raw HTML fallback rendering.
Previously, standard HTML nodes could be injected into the DOM without full sanitization, allowing dangerous attributes like `onerror` to execute. This update sanitizes fallback HTML consistently before rendering.

## Changes
- [x] Add shared HTML sanitization for raw HTML fallback content in the markdown parser utilities
- [x] Sanitize Vue 3 raw HTML fallback rendering for `html_inline` and `html_block`
- [x] Sanitize Vue 2 raw HTML fallback rendering for `html_inline` and `html_block`
- [x] Sanitize React raw HTML fallback rendering for `html_inline` and `html_block`
- [x] Add regression coverage for dangerous attributes, unsafe URLs, and blocked tags
- [x] Verify that safe HTML still renders while dangerous payloads no longer execute

## Screenshots / Demo (if UI/behavior changes)

- [x] Added GIF/screenshot
**before**
<img width="1120" height="504" alt="image" src="https://github.com/user-attachments/assets/ecbee581-1a7f-4a4f-b030-ecf5d9cdb680" />
**after**
<img width="1182" height="426" alt="image" src="https://github.com/user-attachments/assets/6ef762bd-2fc0-49d9-a961-b272827b065b" />

## Checklist

- [x] Lint: pnpm lint
- [x] Typecheck: pnpm typecheck
- [x] Tests: pnpm test (or pnpm test:update if snapshots changed)
- [x] Build: pnpm build (library + CSS)
